### PR TITLE
fix: fix vm path in the docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN chmod +x rustup-init
 RUN ./rustup-init -y --no-modify-path --default-toolchain 1.53.0; rm rustup-init
 RUN chmod -R a+w $RUSTUP_HOME $CARGO_HOME
 RUN cd $(go list -f "{{ .Dir }}" -m github.com/line/wasmvm) && \
+    cd ./libwasmvm && \
     RUSTFLAGS='-C target-feature=-crt-static' cargo build --release --example staticlib && \
     mv -f target/release/examples/libstaticlib.a /usr/lib/libwasmvm_static.a && \
     rm -rf target


### PR DESCRIPTION
vm path changed by 0.16.3-0.5.1

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In 0.16.3-0.5.1, the path of the vm was changed but not applied in `dockerfile`.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I followed the [contributing guidelines](https://github.com/line/lbm/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
