### PR TITLE
build: update release bundle structure for cosmovisor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Build, CI
 * (ci) [\#185](https://github.com/Finschia/finschia/pull/185) update `tag.yml` github action
 * (ci) [\#189](https://github.com/Finschia/finschia/pull/189) add dependabot github action
+* (ci) [\#211](https://github.com/Finschia/finschia/pull/211) Publish static binary
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Build, CI
 * (ci) [\#185](https://github.com/Finschia/finschia/pull/185) update `tag.yml` github action
 * (ci) [\#189](https://github.com/Finschia/finschia/pull/189) add dependabot github action
-* (ci) [\#211](https://github.com/Finschia/finschia/pull/211) Publish static binary
+* (build) [\#211](https://github.com/Finschia/finschia/pull/211) Update release bundle structure for cosmovisor
 
 ### Docs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,9 @@
 # > docker build --platform="linux/amd64" -t finschia/finschianode . --build-arg ARCH=x86_64
 # > docker run -it -p 26656:26656 -p 26657:26657 -v ~/.finschia:/root/.finschia -v finschia/finschianode fnsad init
 # > docker run -it -p 26656:26656 -p 26657:26657 -v ~/.finschia:/root/.finschia -v finschia/finschianode fnsad start --rpc.laddr=tcp://0.0.0.0:26657 --p2p.laddr=tcp://0.0.0.0:26656
-FROM golang:1.18-alpine AS build-env
+FROM golang:1.18-bullseye AS build-env
 ARG ARCH=$ARCH
 ARG FINSCHIA_BUILD_OPTIONS=""
-
-# Set up OS dependencies
-ENV PACKAGES curl wget make cmake git libc-dev bash gcc g++ linux-headers eudev-dev python3 perl
-RUN apk add --update --no-cache $PACKAGES
 
 # Set WORKDIR to finschia
 WORKDIR /finschia-build/finschia
@@ -24,26 +20,19 @@ COPY ./go.mod /finschia-build/finschia/go.mod
 COPY ./go.sum /finschia-build/finschia/go.sum
 RUN go mod download
 
-# Install libwasmvm.*.a
-COPY ./builders/scripts/install-libwasmvm.sh ./
-RUN sh install-libwasmvm.sh && rm install-libwasmvm.sh
-
-RUN ln -s /lib/libwasmvm_muslc.${ARCH}.a /usr/lib/libwasmvm_muslc.a
-
 # Add source files
 COPY . .
 
-# Make install
-RUN BUILD_TAGS=muslc make install CGO_ENABLED=1 FINSCHIA_BUILD_OPTIONS="$FINSCHIA_BUILD_OPTIONS"
+# Make release bundle
+RUN make build-release-bundle FINSCHIA_BUILD_OPTIONS="$FINSCHIA_BUILD_OPTIONS"
+RUN cd build && tar -xzf finschia-*.tgz
 
 # Final image
-FROM alpine:edge
+FROM debian:bullseye
+ARG ARCH=$ARCH
 
 WORKDIR /root
 
-# Set up OS dependencies
-RUN apk add --update --no-cache libstdc++ ca-certificates
-
 # Copy over binaries from the build-env
-COPY --from=build-env /go/bin/fnsad /usr/bin/fnsad
-
+COPY --from=build-env /finschia-build/finschia/build/libwasmvm.${ARCH}.so /usr/lib/
+COPY --from=build-env /finschia-build/finschia/build/fnsad /usr/bin/

--- a/Makefile
+++ b/Makefile
@@ -180,18 +180,18 @@ build-release-bundle: build
 	@if [   -z "${LIBWASMVM_PATH}" ]; then echo "ERROR: $(LIBWASMVM) $(LIBWASMVM_VERSION) not found: $(shell go env GOMODCACHE)"; exit 1; fi
 	@if [ ! -f "${LIBWASMVM_PATH}" ]; then echo "ERROR: Multiple version of $(LIBWASMVM) found: ${LIBWASMVM_PATH}"; exit 1; fi
 	@mkdir -p $(BUILDDIR)/$(RELEASE_BUNDLE)
-	@cp $(BUILDDIR)/fnsad $(BUILDDIR)/$(RELEASE_BUNDLE)/$(RELEASE_BUNDLE)
+	@cp $(BUILDDIR)/fnsad $(BUILDDIR)/$(RELEASE_BUNDLE)/
 	@cp "$(LIBWASMVM_PATH)" $(BUILDDIR)/$(RELEASE_BUNDLE)/
 	@case "$(shell go env GOHOSTOS),$(shell go env GOHOSTARCH),$(shell go env GOARCH)" in \
 	  *,amd64,amd64 | *,arm64,arm64 | darwin,arm64,*) \
-	    LD_LIBRARY_PATH=$(BUILDDIR)/$(RELEASE_BUNDLE) $(BUILDDIR)/$(RELEASE_BUNDLE)/$(RELEASE_BUNDLE) version; \
+	    LD_LIBRARY_PATH=$(BUILDDIR)/$(RELEASE_BUNDLE) $(BUILDDIR)/$(RELEASE_BUNDLE)/fnsad version; \
 	    if [ $$? -ne 0 ]; then echo "ERROR: Test execution failed."; printenv; go env; exit 1; fi; \
 	    echo "OK: Test execution confirmed.";; \
       *) \
         echo "SKIP: Test execution unconfirmed.";; \
     esac
-	@cd $(BUILDDIR) && tar zcvf ./$(RELEASE_BUNDLE).tgz $(RELEASE_BUNDLE)/ > /dev/null 2>&1
-	@rm -rf $(BUILDDIR)/$(RELEASE_BUNDLE)/
+	@cd $(BUILDDIR)/$(RELEASE_BUNDLE) && tar zcvf ../$(RELEASE_BUNDLE).tgz * > /dev/null 2>&1
+	@cd .. && rm -rf $(BUILDDIR)/$(RELEASE_BUNDLE)/
 	@echo "Built: $(BUILDDIR)/$(RELEASE_BUNDLE).tgz"
 
 install: go.sum $(BUILDDIR)/ dbbackend $(LIBSODIUM_TARGET)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This patch would change the contents of the release bundle tar file, into:
- fnsad
- libwasmvm.ARCH.so

cosmovisor would download this bundle tar file and place the files into the corresponding upgrade folder.

This patch would also change the base image of the root `Dockerfile` into `debian:bullseye`.

closes: #210 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/finschia/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
