### PR TITLE
fix: add wasmplus proposal command in `fnsad` cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Improvements
 
 ### Bug Fixes
+* (x/wasm) [\#217](https://github.com/Finschia/finschia/pull/217) add wasmplus proposal command in fnsad cli
 
 ### Breaking Changes
 

--- a/app/app.go
+++ b/app/app.go
@@ -116,9 +116,9 @@ import (
 	ibchost "github.com/Finschia/ibc-go/v3/modules/core/24-host"
 	ibckeeper "github.com/Finschia/ibc-go/v3/modules/core/keeper"
 	"github.com/Finschia/wasmd/x/wasm"
-	wasmclient "github.com/Finschia/wasmd/x/wasm/client"
 	wasmkeeper "github.com/Finschia/wasmd/x/wasm/keeper"
 	"github.com/Finschia/wasmd/x/wasmplus"
+	wasmplusclient "github.com/Finschia/wasmd/x/wasmplus/client"
 	wasmpluskeeper "github.com/Finschia/wasmd/x/wasmplus/keeper"
 	wasmplustypes "github.com/Finschia/wasmd/x/wasmplus/types"
 
@@ -149,7 +149,7 @@ var (
 		foundationmodule.AppModuleBasic{},
 		gov.NewAppModuleBasic(
 			append(
-				wasmclient.ProposalHandlers,
+				wasmplusclient.ProposalHandlers,
 				paramsclient.ProposalHandler,
 				distrclient.ProposalHandler,
 				upgradeclient.ProposalHandler,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
closes: #215 

Add have wasmplus gov proposal command in `fnsad` cli. `activate-contract`, `deactivate-contract`.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are not `activate-contract` and `deactivate-contract` gov command in `fnsad` cli of finschia v1.0.0.


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
$ fnsad tx gov submit-proposal deactivate-contract
Error: accepts 1 arg(s), received 0
Usage:
  fnsad tx gov submit-proposal deactivate-contract [contract_addr_bech32] [flags]
….
```

```
$ fnsad tx gov submit-proposal activate-contract 
Error: accepts 1 arg(s), received 0
Usage:
  fnsad tx gov submit-proposal activate-contract [contract_addr_bech32] [flags]
…..
```

## Screenshots (if appropriate):
![스크린샷_2023-06-10_오후_10_19_42](https://github.com/Finschia/finschia/assets/3938725/2c23e825-9ac9-48a8-b94a-b369faf06255)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/finschia/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
