### PR TITLE
feat!: remove `libsodium` vrf library.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,16 +108,9 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get install -y build-essential libtool autoconf automake
-      - name: install libsodium
-        run: |
-          make libsodium
-        if: env.GIT_DIFF
       - name: test & coverage report creation
-        env:
-          CGO_CFLAGS: "-I${{ github.workspace }}/tools/sodium/linux_amd64/include"
-          CGO_LDFLAGS: "-L${{ github.workspace }}/tools/sodium/linux_amd64/lib -lsodium"
         run: |
-          cat pkgs.txt.part.${{ matrix.part }} | xargs go test -mod=readonly -timeout 30m -coverprofile=${{ matrix.part }}profile.out -covermode=atomic -tags='ledger test_ledger_mock goleveldb gcc libsodium'
+          cat pkgs.txt.part.${{ matrix.part }} | xargs go test -mod=readonly -timeout 30m -coverprofile=${{ matrix.part }}profile.out -covermode=atomic -tags='ledger test_ledger_mock goleveldb gcc'
         if: env.GIT_DIFF
       - uses: actions/upload-artifact@v3
         with:
@@ -199,16 +192,9 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get install -y build-essential libtool autoconf automake
-      - name: install libsodium
-        run: |
-          make libsodium
-        if: env.GIT_DIFF
       - name: test & coverage report creation
-        env:
-          CGO_CFLAGS: "-I${{ github.workspace }}/tools/sodium/linux_amd64/include"
-          CGO_LDFLAGS: "-L${{ github.workspace }}/tools/sodium/linux_amd64/lib -lsodium"
         run: |
-          xargs --arg-file=pkgs.txt.part.${{ matrix.part }} go test -mod=readonly -json -timeout 30m -tags='cli_test goleveldb gcc libsodium' | tee ${{ matrix.part }}-integration-output.txt
+          xargs --arg-file=pkgs.txt.part.${{ matrix.part }} go test -mod=readonly -json -timeout 30m -tags='cli_test goleveldb gcc' | tee ${{ matrix.part }}-integration-output.txt
         if: env.GIT_DIFF
       - uses: actions/upload-artifact@v3
         with:
@@ -279,15 +265,9 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get install -y build-essential libtool autoconf automake
-      - name: install libsodium
-        run: make libsodium
-        if: env.GIT_DIFF
       - name: test report creation
-        env:
-          CGO_CFLAGS: "-I${{ github.workspace }}/tools/sodium/linux_amd64/include"
-          CGO_LDFLAGS: "-L${{ github.workspace }}/tools/sodium/linux_amd64/lib -lsodium"
         run: |
-          xargs --arg-file=pkgs.txt.part.${{ matrix.part }} go test -mod=readonly -json -timeout 30m -tags='cli_multi_node_test goleveldb libsodium' | tee ${{ matrix.part }}-integration-multi-node-output.txt
+          xargs --arg-file=pkgs.txt.part.${{ matrix.part }} go test -mod=readonly -json -timeout 30m -tags='cli_multi_node_test goleveldb' | tee ${{ matrix.part }}-integration-multi-node-output.txt
         if: env.GIT_DIFF
       - uses: actions/upload-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -48,9 +48,6 @@ dependency-graph.png
 *.out
 *.synctex.gz
 
-# tools
-tools/sodium
-
 # docs
 /client/docs/tmp-swagger-gen/
 /client/docs/node_modules/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tools/libsodium"]
-	path = tools/libsodium
-	url = https://github.com/algorand/libsodium.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (build) [\#236](https://github.com/Finschia/finschia/pull/236) fix compile error when the build_tags is multiple.
 
 ### Breaking Changes
+* (ostracon) [\#240](https://github.com/Finschia/finschia/pull/240) remove `libsodium` vrf library
 
 ### Build, CI
 * (ci) [\#185](https://github.com/Finschia/finschia/pull/185) update `tag.yml` github action

--- a/Makefile
+++ b/Makefile
@@ -87,15 +87,6 @@ else
   endif
 endif
 
-# VRF library selection
-ifeq (libsodium,$(findstring libsodium,$(FINSCHIA_BUILD_OPTIONS)))
-  CGO_ENABLED=1
-  BUILD_TAGS += gcc libsodium
-  LIBSODIUM_TARGET = libsodium
-  CGO_CFLAGS += "-I$(LIBSODIUM_OS)/include"
-  CGO_LDFLAGS += "-L$(LIBSODIUM_OS)/lib -lsodium"
-endif
-
 # secp256k1 implementation selection
 ifeq (libsecp256k1,$(findstring libsecp256k1,$(FINSCHIA_BUILD_OPTIONS)))
   CGO_ENABLED=1
@@ -159,10 +150,10 @@ all: install lint test
 
 build: BUILD_ARGS=-o $(BUILDDIR)/
 
-build: go.sum $(BUILDDIR)/ dbbackend $(LIBSODIUM_TARGET)
+build: go.sum $(BUILDDIR)/ dbbackend
 	CGO_CFLAGS=$(CGO_CFLAGS) CGO_LDFLAGS=$(CGO_LDFLAGS) CGO_ENABLED=$(CGO_ENABLED) go build -mod=readonly $(BUILD_FLAGS) $(BUILD_ARGS) ./...
 
-install: go.sum $(BUILDDIR)/ dbbackend $(LIBSODIUM_TARGET)
+install: go.sum $(BUILDDIR)/ dbbackend
 	CGO_CFLAGS=$(CGO_CFLAGS) CGO_LDFLAGS=$(CGO_LDFLAGS) CGO_ENABLED=$(CGO_ENABLED) go install $(BUILD_FLAGS) $(BUILD_ARGS) ./cmd/fnsad
 
 $(BUILDDIR)/:
@@ -363,30 +354,6 @@ localnet-stop:
 	test test-all test-cover test-unit test-race \
 	benchmark \
 	localnet-start localnet-stop
-
-###############################################################################
-###                                  tools                                  ###
-###############################################################################
-
-VRF_ROOT = $(shell pwd)/tools
-LIBSODIUM_ROOT = $(VRF_ROOT)/libsodium
-LIBSODIUM_OS = $(VRF_ROOT)/sodium/$(shell go env GOOS)_$(shell go env GOARCH)
-ifneq ($(TARGET_HOST), "")
-LIBSODIUM_HOST = "--host=$(TARGET_HOST)"
-endif
-
-libsodium:
-	@if [ ! -f $(LIBSODIUM_OS)/lib/libsodium.a ]; then \
-		rm -rf $(LIBSODIUM_ROOT) && \
-		mkdir $(LIBSODIUM_ROOT) && \
-		git submodule update --init --recursive && \
-		cd $(LIBSODIUM_ROOT) && \
-		./autogen.sh && \
-		./configure --disable-shared --prefix="$(LIBSODIUM_OS)" $(LIBSODIUM_HOST) && \
-		$(MAKE) && \
-		$(MAKE) install; \
-	fi
-.PHONY: libsodium
 
 ###############################################################################
 ###                                Proto                                    ###

--- a/Makefile
+++ b/Makefile
@@ -87,12 +87,6 @@ else
   endif
 endif
 
-# secp256k1 implementation selection
-ifeq (libsecp256k1,$(findstring libsecp256k1,$(FINSCHIA_BUILD_OPTIONS)))
-  CGO_ENABLED=1
-  BUILD_TAGS += libsecp256k1
-endif
-
 build_tags += $(BUILD_TAGS)
 build_tags := $(strip $(build_tags))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove unused shared library 
* libsodium
* libsecp256k1

The `libsodium` vrf library doesn't need any more through https://github.com/Finschia/ostracon/pull/652.
So I remove it for preparing single binaries on macos. This is related with #231.
To build single binary, there should be no dynamic library except `cleveldb`.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ostracon does not use the `libsodium` vrf library and it changed to `curve25519-voi`. So `libsodium` submodule and build scripts are not need any more. And I need this remove any dynamic libraries or change to static libraries for building single binary on macos. So I need to remove libsodium first.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/finschia/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
