### PR TITLE
build: use curl instead of wget on MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (build) [\#237](https://github.com/Finschia/finschia/pull/237) rearrange Dockerfile and Makefile commands
 * (build) [\#241](https://github.com/Finschia/finschia/pull/241) Update golang version to 1.20
 * (build) [\#259](https://github.com/Finschia/finschia/pull/259) change default build to be compiled as static binary
+* (build) [\#284](https://github.com/Finschia/finschia/pull/284) use curl instead of wget on MacOS
 
 ### Docs
 * (docs) [\#281](https://github.com/Finschia/finschia/pull/281) Update guide for static build on CentOS 

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ ifeq ($(LINK_STATICALLY),true)
 	@mkdir -p $(TEMPDIR)/lib
     ifeq (",$(wildcard $(TEMPDIR)/lib/libwasmvm*.a)")
         ifeq ($(OS_NAME),darwin)
-	        wget https://github.com/Finschia/wasmvm/releases/download/$(WASMVM_VERSION)/libwasmvmstatic_darwin.a -O $(TEMPDIR)/lib/libwasmvmstatic_darwin.a
+	        curl -L https://github.com/Finschia/wasmvm/releases/download/$(WASMVM_VERSION)/libwasmvmstatic_darwin.a -o $(TEMPDIR)/lib/libwasmvmstatic_darwin.a
         else
             ifeq ($(ARCH),amd64)
 	            wget https://github.com/Finschia/wasmvm/releases/download/$(WASMVM_VERSION)/libwasmvm_muslc.x86_64.a -O $(TEMPDIR)/lib/libwasmvm_muslc.a


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
closes: #XXXX

`wget` is not a default tool on MacOS

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/finschia/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
