### PR TITLE
Release finschia v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,40 +37,16 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ## [Unreleased]
 
 ### Features
-* (feat) [\#243](https://github.com/Finschia/finschia/pull/243) Bump github.com/Finschia/finschia-sdk from v0.47.0 to v0.47.1-rc1
-* (ibc) [\#246](https://github.com/Finschia/finschia/pull/246) Update ibc-go to v4
-* (build) [\#248](https://github.com/Finschia/finschia/pull/248) Rename namespace to v2
-* (app) [\#250](https://github.com/Finschia/finschia/pull/250) Set upgrade handler for v2-Daisy
-* (feat) [\#255](https://github.com/Finschia/finschia/pull/255) Bump up finschia-sdk from v0.48.0-rc1 to da331c01fa
-* (feat) [\#262](https://github.com/Finschia/finschia/pull/262) Bump up finschia-sdk from v0.48.0-rc2 to `0a27aef22921` and bump up ostracon from `449aa3148b12` to `fc29846c918d`
 
 ### Improvements
-* (build) [\#221](https://github.com/Finschia/finschia/pull/221) compile static binary as release assets and docker image
-* (swagger) [\#223](https://github.com/Finschia/finschia/pull/223) add integrated swagger for finschia
-* (wasm) [\#258](https://github.com/Finschia/finschia/pull/258) Bump up wasmd from dedcd9ec to 053c7e43
-* (finschia-sdk, ostracon, wasmd) [\#286](https://github.com/Finschia/finschia/pull/286) bump up fisnchia-sdk to v0.48.0 and Ostracon to v1.1.2 and wasmd to v0.2.0 
 
 ### Bug Fixes
-* (build) [\#236](https://github.com/Finschia/finschia/pull/236) fix compile error when the build_tags is multiple.
-* (wasm) [\#249](https://github.com/Finschia/finschia/pull/249) revert removing wasm configs
-* (finschia-sdk) [\#264](https://github.com/Finschia/finschia/pull/264) Bump up finschia-sdk from `0a27aef22921` to `022614f80a0d`
-* (build) [\#277](https://github.com/Finschia/finschia/pull/277) change to the default build method that uses a shared library
 
 ### Breaking Changes
-* (ostracon) [\#240](https://github.com/Finschia/finschia/pull/240) remove `libsodium` vrf library
 
 ### Build, CI
-* (ci) [\#185](https://github.com/Finschia/finschia/pull/185) update `tag.yml` github action
-* (ci) [\#189](https://github.com/Finschia/finschia/pull/189) add dependabot github action
-* (ci) [\#213](https://github.com/Finschia/finschia/pull/213) add mergify ci
-* (ci) [\#233](https://github.com/Finschia/finschia/pull/233) add smart contract CI test
-* (build) [\#237](https://github.com/Finschia/finschia/pull/237) rearrange Dockerfile and Makefile commands
-* (build) [\#241](https://github.com/Finschia/finschia/pull/241) Update golang version to 1.20
-* (build) [\#259](https://github.com/Finschia/finschia/pull/259) change default build to be compiled as static binary
-* (build) [\#284](https://github.com/Finschia/finschia/pull/284) use curl instead of wget on MacOS
 
 ### Docs
-* (docs) [\#281](https://github.com/Finschia/finschia/pull/281) Update guide for static build on CentOS 
 
 <!-- Release links -->
-[Unreleased]: https://github.com/Finschia/finschia/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/Finschia/finschia/compare/v2.0.0...HEAD

--- a/RELEASE_CHANGELOG.md
+++ b/RELEASE_CHANGELOG.md
@@ -34,6 +34,53 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## [v2.0.0] - 2023-10-19
+
+This version base on [finschia-sdk v0.48.0](https://github.com/Finschia/finschia-sdk/releases/tag/v0.48.0), [Ostracon v1.1.2](https://github.com/Finschia/ostracon/tree/v1.1.2), [finschia/wasmd v0.2.0](https://github.com/Finschia/wasmd/releases/tag/v0.2.0) and [finschia/ibc-go v4.3.1](https://github.com/Finschia/ibc-go/releases/tag/v4.3.1).
+
+### Features
+* (finschia-sdk) Bump github.com/Finschia/finschia-sdk from v0.47.0 to v0.48.0
+  * (feat) [\#243](https://github.com/Finschia/finschia/pull/243) Bump github.com/Finschia/finschia-sdk from v0.47.0 to v0.47.1-rc1
+  * (feat) [\#255](https://github.com/Finschia/finschia/pull/255) Bump up finschia-sdk from v0.48.0-rc1 to da331c01fa
+  * (feat) [\#262](https://github.com/Finschia/finschia/pull/262) Bump up finschia-sdk from v0.48.0-rc2 to `0a27aef22921` and bump up ostracon from `449aa3148b12` to `fc29846c918d`
+  * (finschia-sdk, ostracon, wasmd) [\#286](https://github.com/Finschia/finschia/pull/286) bump up fisnchia-sdk to v0.48.0 and Ostracon to v1.1.2 and wasmd to v0.2.0
+* (ostracon) Bump up Ostracon from v1.1.0 to v1.1.2
+  * (feat) [\#262](https://github.com/Finschia/finschia/pull/262) Bump up finschia-sdk from v0.48.0-rc2 to `0a27aef22921` and bump up ostracon from `449aa3148b12` to `fc29846c918d`
+  * (finschia-sdk, ostracon, wasmd) [\#286](https://github.com/Finschia/finschia/pull/286) bump up fisnchia-sdk to v0.48.0 and Ostracon to v1.1.2 and wasmd to v0.2.0
+* (wasmd) bump up wasmd from v0.1.3 to v0.2.0
+  * (wasm) [\#258](https://github.com/Finschia/finschia/pull/258) Bump up wasmd from dedcd9ec to 053c7e43
+  * (finschia-sdk, ostracon, wasmd) [\#286](https://github.com/Finschia/finschia/pull/286) bump up fisnchia-sdk to v0.48.0 and Ostracon to v1.1.2 and wasmd to v0.2.0
+* (ibc) [\#246](https://github.com/Finschia/finschia/pull/246) Update ibc-go to v4
+* (build) [\#248](https://github.com/Finschia/finschia/pull/248) Rename namespace to v2
+* (app) [\#250](https://github.com/Finschia/finschia/pull/250) Set upgrade handler for v2-Daisy
+
+### Improvements
+* (build) [\#221](https://github.com/Finschia/finschia/pull/221) compile static binary as release assets and docker image
+* (swagger) [\#223](https://github.com/Finschia/finschia/pull/223) add integrated swagger for finschia
+
+### Bug Fixes
+* (build) [\#236](https://github.com/Finschia/finschia/pull/236) fix compile error when the build_tags is multiple.
+* (wasm) [\#249](https://github.com/Finschia/finschia/pull/249) revert removing wasm configs
+* (finschia-sdk) [\#264](https://github.com/Finschia/finschia/pull/264) Bump up finschia-sdk from `0a27aef22921` to `022614f80a0d`
+* (build) [\#277](https://github.com/Finschia/finschia/pull/277) change to the default build method that uses a shared library
+
+### Breaking Changes
+* (ostracon) [\#240](https://github.com/Finschia/finschia/pull/240) remove `libsodium` vrf library
+
+### Build, CI
+* (ci) [\#185](https://github.com/Finschia/finschia/pull/185) update `tag.yml` github action
+* (ci) [\#189](https://github.com/Finschia/finschia/pull/189) add dependabot github action
+* (ci) [\#213](https://github.com/Finschia/finschia/pull/213) add mergify ci
+* (ci) [\#233](https://github.com/Finschia/finschia/pull/233) add smart contract CI test
+* (build) [\#237](https://github.com/Finschia/finschia/pull/237) rearrange Dockerfile and Makefile commands
+* (build) [\#241](https://github.com/Finschia/finschia/pull/241) Update golang version to 1.20
+* (build) [\#259](https://github.com/Finschia/finschia/pull/259) change default build to be compiled as static binary
+* (build) [\#284](https://github.com/Finschia/finschia/pull/284) use curl instead of wget on MacOS
+
+### Docs
+* (docs) [\#281](https://github.com/Finschia/finschia/pull/281) Update guide for static build on CentOS
+
+
 ## [v1.0.0] - 2023-04-24
 
 This version base on [finschia-sdk v0.47.0](https://github.com/Finschia/finschia-sdk/releases/tag/v0.47.0), [Ostracon v1.1.0](https://github.com/Finschia/ostracon/tree/v1.1.0), [finschia/wasmd v0.1.3](https://github.com/Finschia/wasmd/releases/tag/v0.1.3) and [finschia/ibc-go v3.3.3](https://github.com/Finschia/ibc-go/releases/tag/v3.3.3).
@@ -205,6 +252,7 @@ Please refer [CHANGELOG_OF_GAIA_v4.0.4](https://github.com/cosmos/gaia/blob/v4.0
 
 
 <!-- Release links -->
+[v2.0.0]: https://github.com/Finschia/finschia/releases/tag/v2.0.0
 [v1.0.0]: https://github.com/Finschia/finschia/releases/tag/v1.0.0
 [v0.7.0]: https://github.com/Finschia/finschia/releases/tag/v0.7.0
 [v0.6.0]: https://github.com/Finschia/finschia/releases/tag/v0.6.0

--- a/RELEASE_CHANGELOG.md
+++ b/RELEASE_CHANGELOG.md
@@ -43,6 +43,7 @@ This version base on [finschia-sdk v0.48.0](https://github.com/Finschia/finschia
   * (feat) [\#243](https://github.com/Finschia/finschia/pull/243) Bump github.com/Finschia/finschia-sdk from v0.47.0 to v0.47.1-rc1
   * (feat) [\#255](https://github.com/Finschia/finschia/pull/255) Bump up finschia-sdk from v0.48.0-rc1 to da331c01fa
   * (feat) [\#262](https://github.com/Finschia/finschia/pull/262) Bump up finschia-sdk from v0.48.0-rc2 to `0a27aef22921` and bump up ostracon from `449aa3148b12` to `fc29846c918d`
+  * (finschia-sdk) [\#264](https://github.com/Finschia/finschia/pull/264) Bump up finschia-sdk from `0a27aef22921` to `022614f80a0d`
   * (finschia-sdk, ostracon, wasmd) [\#286](https://github.com/Finschia/finschia/pull/286) bump up fisnchia-sdk to v0.48.0 and Ostracon to v1.1.2 and wasmd to v0.2.0
 * (ostracon) Bump up Ostracon from v1.1.0 to v1.1.2
   * (feat) [\#262](https://github.com/Finschia/finschia/pull/262) Bump up finschia-sdk from v0.48.0-rc2 to `0a27aef22921` and bump up ostracon from `449aa3148b12` to `fc29846c918d`
@@ -61,7 +62,6 @@ This version base on [finschia-sdk v0.48.0](https://github.com/Finschia/finschia
 ### Bug Fixes
 * (build) [\#236](https://github.com/Finschia/finschia/pull/236) fix compile error when the build_tags is multiple.
 * (wasm) [\#249](https://github.com/Finschia/finschia/pull/249) revert removing wasm configs
-* (finschia-sdk) [\#264](https://github.com/Finschia/finschia/pull/264) Bump up finschia-sdk from `0a27aef22921` to `022614f80a0d`
 * (build) [\#277](https://github.com/Finschia/finschia/pull/277) change to the default build method that uses a shared library
 
 ### Breaking Changes

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -12,8 +12,8 @@ Check out the [changelog](https://github.com/Finschia/finschia/blob/v2.0.0/RELEA
 * Upgrade finschia-sdk to [v0.48.0](https://github.com/Finschia/finschia-sdk/releases/tag/v0.48.0)
   * Migrate x/foundation FoundationTax into x/params
   * Add tendermint query apis for compatibility with cosmos-sdk
-  * Make x/foundation MsgExec propagate events
   * Support custom r/w gRPC options
+  * Make x/foundation MsgExec propagate events
   * Fix `MsgMintFT` bug in x/collection module
   * Fix bug where nano S plus ledger could not be connected in Ubuntu
 * Upgrade wasmd to [v0.2.0](https://github.com/Finschia/wasmd/releases/tag/v0.2.0)

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -6,24 +6,24 @@ Check out the [changelog](https://github.com/Finschia/finschia/blob/v2.0.0/RELEA
 ## Highlights
 * Upgrade to Golang v1.20
 * Upgrade to Ostracon [v1.1.2](https://github.com/Finschia/ostracon/tree/v1.1.2)
-  * change vrf library from `libsodium` to `curve25519-voi`'s VRF
+  * Change vrf library from `libsodium` to `curve25519-voi`'s VRF
   * Apply changes up to tendermint v0.34.24
   * Improve KMS features of IP filter and multiple allow IPs
 * Upgrade finschia-sdk to [v0.48.0](https://github.com/Finschia/finschia-sdk/releases/tag/v0.48.0)
+  * Migrate x/foundation FoundationTax into x/params
+  * Add tendermint query apis for compatibility with cosmos-sdk
   * Make x/foundation MsgExec propagate events
-  * fix `MsgMintFT` bug in x/collection module
-  * migrate x/foundation FoundationTax into x/params
-  * add tendermint query apis for compatibility with cosmos-sdk
+  * Support custom r/w gRPC options
+  * Fix `MsgMintFT` bug in x/collection module
   * Fix bug where nano S plus ledger could not be connected in Ubuntu
-  * support custom r/w gRPC options
 * Upgrade wasmd to [v0.2.0](https://github.com/Finschia/wasmd/releases/tag/v0.2.0)
 * Upgrade ibc-go to [v4.3.1](https://github.com/Finschia/ibc-go/releases/tag/v4.3.1)
-* integrate swagger of all submodules
-* support static binary compile
+* Integrate swagger of all submodules
+* Support static binary compile
 
 ## Base sub modules
 * Ostracon: [v1.1.2](https://github.com/Finschia/ostracon/tree/v1.1.2)
-* finschia-sdk: [v0.48.0](https://github.com/Finschia/finschia-sdk/tree/v0.48.0)
+* Finschia-sdk: [v0.48.0](https://github.com/Finschia/finschia-sdk/tree/v0.48.0)
 * Finschia/wasmd: [v0.2.0](https://github.com/Finschia/wasmd/tree/v0.2.0)
 * Finschia/ibc-go: [v4.3.1](https://github.com/Finschia/ibc-go/tree/v4.3.1)
 

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -4,7 +4,6 @@
 Check out the [changelog](https://github.com/Finschia/finschia/blob/v2.0.0/RELEASE_CHANGELOG.md) for a list of relevant changes or [compare all changes](https://github.com/Finschia/finschia/compare/v1.0.0...v2.0.0) from last release
 
 ## Highlights
-* Upgrade to Golang v1.20
 * Upgrade to Ostracon [v1.1.2](https://github.com/Finschia/ostracon/tree/v1.1.2)
   * Change vrf library from `libsodium` to `curve25519-voi`'s VRF
   * Apply changes up to tendermint v0.34.24
@@ -18,6 +17,7 @@ Check out the [changelog](https://github.com/Finschia/finschia/blob/v2.0.0/RELEA
   * Fix bug where nano S plus ledger could not be connected in Ubuntu
 * Upgrade wasmd to [v0.2.0](https://github.com/Finschia/wasmd/releases/tag/v0.2.0)
 * Upgrade ibc-go to [v4.3.1](https://github.com/Finschia/ibc-go/releases/tag/v4.3.1)
+* Upgrade to Golang v1.20
 * Integrate swagger of all submodules
 * Support static binary compile
 

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -1,56 +1,41 @@
-# Finschia v1.0.0 Release Note
+# Finschia v2.0.0 Release Note
 
-## What's Changes
-This version base on [finschia-sdk v0.47.0](https://github.com/Finschia/finschia-sdk/releases/tag/v0.47.0), [Ostracon v1.1.0](https://github.com/Finschia/ostracon/tree/v1.1.0), [finschia/wasmd v0.1.3](https://github.com/Finschia/wasmd/releases/tag/v0.1.3) and [finschia/ibc-go v3.3.3](https://github.com/Finschia/ibc-go/releases/tag/v3.3.3).
+## Changelog
+Check out the [changelog](https://github.com/Finschia/finschia/blob/v2.0.0/RELEASE_CHANGELOG.md) for a list of relevant changes or [compare all changes](https://github.com/Finschia/finschia/compare/v1.0.0...v2.0.0) from last release
 
-### Features
-* (build) [\#126](https://github.com/Finschia/finschia/pull/126) Automatically generates release note and binaries
-* (x/wasmd) [\#129](https://github.com/Finschia/finschia/pull/129) chore: apply detached x/wasmd
-* (build) [\#130](https://github.com/Finschia/finschia/pull/130) Add a release build for the linux/arm64, darwin/amd64, and darwin/arm64 platform
-* (finschia-sdk) [\#137](https://github.com/Finschia/finschia/pull/137) Bump finschia-sdk to 6c84a4cffa
-* (x/collection,token) [\#138](https://github.com/Finschia/finschia/pull/138) Add x/token and x/collection
-* (ibc-go) [\#140](https://github.com/Finschia/finschia/pull/140) apply ibc-go
-* (x/wasmplus) [\#141](https://github.com/Finschia/finschia/pull/141) change wasm module to wrapped `x/wasmplus`
-* (finschia-sdk) [\#144](https://github.com/Finschia/finschia/pull/144) bump finschia-sdk v0.47.0-alpha1 (11966d1234155ebef20b64f2ae7a905beffdb33f)
-* (build) [\#150](https://github.com/Finschia/finschia/pull/150) Modify the Makefile to build release bundles
-* (build) [\#153](https://github.com/Finschia/finschia/pull/153) rename cli name to `fnsad`
-* (finschia-sdk) [\#154](https://github.com/Finschia/finschia/pull/154) Bump finschia-sdk from v0.47.0-alpha1.0.20230214070148-11966d123415 to v0.47.0-rc1
-
-### Improvements
-* (x/wasmd) [\#147](https://github.com/Finschia/finschia/pull/147) update wasmd version
-* (x/wasmd) [\#158](https://github.com/Finschia/finschia/pull/158) bump up wasmd version to v0.1.0
-* (finschia-sdk) [\#159](https://github.com/Finschia/finschia/pull/159) Bump finschia-sdk from v0.47.0-rc1 to v0.47.0-rc2
-* (wasmd) [\#171](https://github.com/Finschia/finschia/pull/171) bump up wasmd from v0.1.2-0.20230403061848-514953c0b244 to v0.1.2
-
-### Bug Fixes
-* (finschia-sdk) [\#162](https://github.com/Finschia/finschia/pull/162) Bump finschia-sdk from v0.47.0-rc2 to v0.47.0-rc3
-* (finschia-sdk) [\#167](https://github.com/Finschia/finschia/pull/167) Bump finschia-sdk from v0.47.0-rc3 to v0.47.0-rc4
-* (finschia-sdk) [\#178](https://github.com/Finschia/finschia/pull/178) Bump github.com/Finschia/finschia-sdk from v0.47.0-rc6 to v0.47.0-rc7
-* (finschia-sdk) [\#168](https://github.com/Finschia/finschia/pull/168) Bump finschia-sdk from v0.47.0-rc4 to v0.47.0-rc4.0.20230410115856-b8421116b3f2
-* (finschia-sdk) [\#172](https://github.com/Finschia/finschia/pull/172) Bump finschia-sdk from v0.47.0-rc4.0.20230410115856-b8421116b3f2 to v0.47.0-rc5
-* (finschia-sdk) [\#174](https://github.com/Finschia/finschia/pull/174) bump up finschia-sdk from v0.47.0-rc5 to v0.47.0-rc5.0.20230414034539-489c442416cd
-
-### Breaking Changes
-* (api) [\#123](https://github.com/Finschia/finschia/pull/123) remove legacy REST API routes
-* (ibc-go)[\#164](https://github.com/Finschia/finschia/pull/164) bump up ibc-go v3.3.2 for change ibc light client of Ostracon to Tendermint
-
-### Build, CI
-* (ci) [\#145](https://github.com/Finschia/finschia/pull/145) add github action to push docker image to docker.io
-* (build) [\#157](https://github.com/Finschia/finschia/pull/157) add build args
-* (ci)[\#163](https://github.com/Finschia/finschia/pull/163) fix `release-build` ci error occurred when adding assets after tagging
-* (finschia-sdk,ostracon,wasmd,ibc-go) [\#176](https://github.com/Finschia/finschia/pull/176) Rename and bump up dependencies
-* (ci) [\#180](https://github.com/Finschia/finschia/pull/180) add a CI to build darwin version when add tag
-
-### Docs
-* (doc) [\#156](https://github.com/Finschia/finschia/pull/156) modify broken link or typo doc file and add issue and pr template
-* (doc)[\#165](https://github.com/Finschia/finschia/pull/165) update license notice and code_of_conduct
-* (license) [\#170](https://github.com/Finschia/finschia/pull/170) fix license copyright holder and typo
-
+## Highlights
+* Upgrade to Golang v1.20
+* Upgrade to Ostracon [v1.1.2](https://github.com/Finschia/ostracon/tree/v1.1.2)
+  * change vrf library from `libsodium` to `curve25519-voi`'s VRF
+  * Apply changes up to tendermint v0.34.24
+  * Improve KMS features of IP filter and multiple allow IPs
+* Upgrade finschia-sdk to [v0.48.0](https://github.com/Finschia/finschia-sdk/releases/tag/v0.48.0)
+  * Make x/foundation MsgExec propagate events
+  * fix `MsgMintFT` bug in x/collection module
+  * migrate x/foundation FoundationTax into x/params
+  * add tendermint query apis for compatibility with cosmos-sdk
+  * Fix bug where nano S plus ledger could not be connected in Ubuntu
+  * support custom r/w gRPC options
+* Upgrade wasmd to [v0.2.0](https://github.com/Finschia/wasmd/releases/tag/v0.2.0)
+* Upgrade ibc-go to [v4.3.1](https://github.com/Finschia/ibc-go/releases/tag/v4.3.1)
+* integrate swagger of all submodules
+* support static binary compile
 
 ## Base sub modules
-* Ostracon: [v1.1.0](https://github.com/Finschia/ostracon/tree/v1.1.0)
-* finschia-sdk: [v0.47.0](https://github.com/Finschia/finschia-sdk/tree/v0.47.0)
-* Finschia/wasmd: [v0.1.3](https://github.com/Finschia/wasmd/tree/v0.1.3)
-* Finschia/ibc-go: [v3.3.3](https://github.com/Finschia/ibc-go/tree/v3.3.3)
+* Ostracon: [v1.1.2](https://github.com/Finschia/ostracon/tree/v1.1.2)
+* finschia-sdk: [v0.48.0](https://github.com/Finschia/finschia-sdk/tree/v0.48.0)
+* Finschia/wasmd: [v0.2.0](https://github.com/Finschia/wasmd/tree/v0.2.0)
+* Finschia/ibc-go: [v4.3.1](https://github.com/Finschia/ibc-go/tree/v4.3.1)
 
-Full Changelog: [v0.7.0...v1.0.0](https://github.com/Finschia/finschia/compare/v0.7.0...v1.0.0)
+
+## Build from source
+You must use Golang v1.20.x if building from source
+```shell
+git clone https://github.com/Finschia/finschia
+cd finschia && git checkout v2.0.0
+make install
+```
+
+## Download binaries
+
+Binaries for linux and darwin are available below.

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -36,6 +36,14 @@ cd finschia && git checkout v2.0.0
 make install
 ```
 
+## Run with Docker
+If you want to run fnsad in a Docker container, you can use the Docker images.
+* docker image: `finschia/finschianode:2.0.0`
+```shell
+docker run finschia/finschianode:2.0.0 fnsad version
+# 2.0.0
+```
+
 ## Download binaries
 
 Binaries for linux and darwin are available below.

--- a/client/docs/config.json
+++ b/client/docs/config.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Finschia - gRPC Gateway docs",
     "description": "A REST interface for state queries, legacy transactions",
-    "version": "1.0.0"
+    "version": "2.0.0"
   },
   "apis": [
     {

--- a/client/docs/swagger-ui/swagger.yaml
+++ b/client/docs/swagger-ui/swagger.yaml
@@ -2,7 +2,7 @@ swagger: '2.0'
 info:
   title: Finschia - gRPC Gateway docs
   description: A REST interface for state queries, legacy transactions
-  version: 1.0.0
+  version: 2.0.0
 paths:
   /cosmos/auth/v1beta1/accounts:
     get:


### PR DESCRIPTION
# Release v2.0.0

This version base on [finschia-sdk v0.48.0](https://github.com/Finschia/finschia-sdk/releases/tag/v0.48.0), [Ostracon v1.1.2](https://github.com/Finschia/ostracon/tree/v1.1.2), [finschia/wasmd v0.2.0](https://github.com/Finschia/wasmd/releases/tag/v0.2.0) and [finschia/ibc-go v4.3.1](https://github.com/Finschia/ibc-go/releases/tag/v4.3.1).

### Features
* (finschia-sdk) Bump github.com/Finschia/finschia-sdk from v0.47.0 to v0.48.0
  * (feat) [\#243](https://github.com/Finschia/finschia/pull/243) Bump github.com/Finschia/finschia-sdk from v0.47.0 to v0.47.1-rc1
  * (feat) [\#255](https://github.com/Finschia/finschia/pull/255) Bump up finschia-sdk from v0.48.0-rc1 to da331c01fa
  * (feat) [\#262](https://github.com/Finschia/finschia/pull/262) Bump up finschia-sdk from v0.48.0-rc2 to `0a27aef22921` and bump up ostracon from `449aa3148b12` to `fc29846c918d`
  * (finschia-sdk) [\#264](https://github.com/Finschia/finschia/pull/264) Bump up finschia-sdk from `0a27aef22921` to `022614f80a0d`
  * (finschia-sdk, ostracon, wasmd) [\#286](https://github.com/Finschia/finschia/pull/286) bump up fisnchia-sdk to v0.48.0 and Ostracon to v1.1.2 and wasmd to v0.2.0
* (ostracon) Bump up Ostracon from v1.1.0 to v1.1.2
  * (feat) [\#262](https://github.com/Finschia/finschia/pull/262) Bump up finschia-sdk from v0.48.0-rc2 to `0a27aef22921` and bump up ostracon from `449aa3148b12` to `fc29846c918d`
  * (finschia-sdk, ostracon, wasmd) [\#286](https://github.com/Finschia/finschia/pull/286) bump up fisnchia-sdk to v0.48.0 and Ostracon to v1.1.2 and wasmd to v0.2.0
* (wasmd) bump up wasmd from v0.1.3 to v0.2.0
  * (wasm) [\#258](https://github.com/Finschia/finschia/pull/258) Bump up wasmd from dedcd9ec to 053c7e43
  * (finschia-sdk, ostracon, wasmd) [\#286](https://github.com/Finschia/finschia/pull/286) bump up fisnchia-sdk to v0.48.0 and Ostracon to v1.1.2 and wasmd to v0.2.0
* (ibc) [\#246](https://github.com/Finschia/finschia/pull/246) Update ibc-go to v4
* (build) [\#248](https://github.com/Finschia/finschia/pull/248) Rename namespace to v2
* (app) [\#250](https://github.com/Finschia/finschia/pull/250) Set upgrade handler for v2-Daisy

### Improvements
* (build) [\#221](https://github.com/Finschia/finschia/pull/221) compile static binary as release assets and docker image
* (swagger) [\#223](https://github.com/Finschia/finschia/pull/223) add integrated swagger for finschia

### Bug Fixes
* (build) [\#236](https://github.com/Finschia/finschia/pull/236) fix compile error when the build_tags is multiple.
* (wasm) [\#249](https://github.com/Finschia/finschia/pull/249) revert removing wasm configs
* (build) [\#277](https://github.com/Finschia/finschia/pull/277) change to the default build method that uses a shared library

### Breaking Changes
* (ostracon) [\#240](https://github.com/Finschia/finschia/pull/240) remove `libsodium` vrf library

