### PR TITLE
Release finschia v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,19 +39,14 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Features
 
 ### Improvements
-* (improvements) [\#230](https://github.com/Finschia/finschia/pull/230) fix Makefile for format and execute make format #230
-* (chore) [\#300](https://github.com/Finschia/finschia/pull/300) remove x/token and x/collection apis in swagger (backport #299)
 
 ### Bug Fixes
-* (finschia-sdk) [\#298](https://github.com/Finschia/finschia/pull/298) bump up finschia-sdk from v0.48.0 to v0.48.1 (backport #297)
 
 ### Breaking Changes
 
 ### Build, CI
-* (ci) [\#290](https://github.com/Finschia/finschia/pull/290) remove autopr ci
-* (ci) [\#291](https://github.com/Finschia/finschia/pull/291) fix goreleaser ci error and replace release-build
 
 ### Docs
 
 <!-- Release links -->
-[Unreleased]: https://github.com/Finschia/finschia/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/Finschia/finschia/compare/v2.0.1...HEAD

--- a/RELEASE_CHANGELOG.md
+++ b/RELEASE_CHANGELOG.md
@@ -34,6 +34,22 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## [v2.0.1] - 2023-11-07
+
+This version base on [finschia-sdk v0.48.1](https://github.com/Finschia/finschia-sdk/releases/tag/v0.48.1), [Ostracon v1.1.2](https://github.com/Finschia/ostracon/tree/v1.1.2), [finschia/wasmd v0.2.0](https://github.com/Finschia/wasmd/releases/tag/v0.2.0) and [finschia/ibc-go v4.3.1](https://github.com/Finschia/ibc-go/releases/tag/v4.3.1).
+
+### Improvements
+* (improvements) [\#230](https://github.com/Finschia/finschia/pull/230) fix Makefile for format and execute make format #230
+* (chore) [\#300](https://github.com/Finschia/finschia/pull/300) remove x/token and x/collection apis in swagger (backport #299)
+
+### Bug Fixes
+* (finschia-sdk) [\#298](https://github.com/Finschia/finschia/pull/298) bump up finschia-sdk from v0.48.0 to v0.48.1 (backport #297)
+
+### Build, CI
+* (ci) [\#290](https://github.com/Finschia/finschia/pull/290) remove autopr ci
+* (ci) [\#291](https://github.com/Finschia/finschia/pull/291) fix goreleaser ci error and replace release-build
+
+
 ## [v2.0.0] - 2023-10-19
 
 This version base on [finschia-sdk v0.48.0](https://github.com/Finschia/finschia-sdk/releases/tag/v0.48.0), [Ostracon v1.1.2](https://github.com/Finschia/ostracon/tree/v1.1.2), [finschia/wasmd v0.2.0](https://github.com/Finschia/wasmd/releases/tag/v0.2.0) and [finschia/ibc-go v4.3.1](https://github.com/Finschia/ibc-go/releases/tag/v4.3.1).
@@ -252,6 +268,7 @@ Please refer [CHANGELOG_OF_GAIA_v4.0.4](https://github.com/cosmos/gaia/blob/v4.0
 
 
 <!-- Release links -->
+[v2.0.1]: https://github.com/Finschia/finschia/releases/tag/v2.0.1
 [v2.0.0]: https://github.com/Finschia/finschia/releases/tag/v2.0.0
 [v1.0.0]: https://github.com/Finschia/finschia/releases/tag/v1.0.0
 [v0.7.0]: https://github.com/Finschia/finschia/releases/tag/v0.7.0

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -1,29 +1,14 @@
-# Finschia v2.0.0 Release Note
+# Finschia v2.0.1 Release Note
 
 ## Changelog
-Check out the [changelog](https://github.com/Finschia/finschia/blob/v2.0.0/RELEASE_CHANGELOG.md) for a list of relevant changes or [compare all changes](https://github.com/Finschia/finschia/compare/v1.0.0...v2.0.0) from last release
+Check out the [changelog](https://github.com/Finschia/finschia/blob/v2.0.1/RELEASE_CHANGELOG.md) for a list of relevant changes or [compare all changes](https://github.com/Finschia/finschia/compare/v2.0.0...v2.0.1) from last release
 
 ## Highlights
-* Upgrade to Ostracon [v1.1.2](https://github.com/Finschia/ostracon/tree/v1.1.2)
-  * Change vrf library from `libsodium` to `curve25519-voi`'s VRF
-  * Apply changes up to tendermint v0.34.24
-  * Improve KMS features of IP filter and multiple allow IPs
-* Upgrade finschia-sdk to [v0.48.0](https://github.com/Finschia/finschia-sdk/releases/tag/v0.48.0)
-  * Migrate x/foundation FoundationTax into x/params
-  * Add tendermint query apis for compatibility with cosmos-sdk
-  * Support custom r/w gRPC options
-  * Make x/foundation MsgExec propagate events
-  * Fix `MsgMintFT` bug in x/collection module
-  * Fix bug where nano S plus ledger could not be connected in Ubuntu
-* Upgrade wasmd to [v0.2.0](https://github.com/Finschia/wasmd/releases/tag/v0.2.0)
-* Upgrade ibc-go to [v4.3.1](https://github.com/Finschia/ibc-go/releases/tag/v4.3.1)
-* Upgrade to Golang v1.20
-* Integrate swagger of all submodules
-* Support static binary compile
+* fix compatible with ledger in MacOS 0.13+
 
 ## Base sub modules
 * Ostracon: [v1.1.2](https://github.com/Finschia/ostracon/tree/v1.1.2)
-* Finschia-sdk: [v0.48.0](https://github.com/Finschia/finschia-sdk/tree/v0.48.0)
+* Finschia-sdk: [v0.48.1](https://github.com/Finschia/finschia-sdk/tree/v0.48.1)
 * Finschia/wasmd: [v0.2.0](https://github.com/Finschia/wasmd/tree/v0.2.0)
 * Finschia/ibc-go: [v4.3.1](https://github.com/Finschia/ibc-go/tree/v4.3.1)
 
@@ -32,16 +17,16 @@ Check out the [changelog](https://github.com/Finschia/finschia/blob/v2.0.0/RELEA
 You must use Golang v1.20.x if building from source
 ```shell
 git clone https://github.com/Finschia/finschia
-cd finschia && git checkout v2.0.0
+cd finschia && git checkout v2.0.1
 make install
 ```
 
 ## Run with Docker
 If you want to run fnsad in a Docker container, you can use the Docker images.
-* docker image: `finschia/finschianode:2.0.0`
+* docker image: `finschia/finschianode:2.0.1`
 ```shell
-docker run finschia/finschianode:2.0.0 fnsad version
-# 2.0.0
+docker run finschia/finschianode:2.0.1 fnsad version
+# 2.0.1
 ```
 
 ## Download binaries

--- a/client/docs/config.json
+++ b/client/docs/config.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Finschia - gRPC Gateway docs",
     "description": "A REST interface for state queries, legacy transactions",
-    "version": "2.0.0"
+    "version": "2.0.1"
   },
   "apis": [
     {

--- a/client/docs/swagger-ui/swagger.yaml
+++ b/client/docs/swagger-ui/swagger.yaml
@@ -2,7 +2,7 @@ swagger: '2.0'
 info:
   title: Finschia - gRPC Gateway docs
   description: A REST interface for state queries, legacy transactions
-  version: 2.0.0
+  version: 2.0.1
 paths:
   /cosmos/auth/v1beta1/accounts:
     get:


### PR DESCRIPTION
This version base on [finschia-sdk v0.48.1](https://github.com/Finschia/finschia-sdk/releases/tag/v0.48.1), [Ostracon v1.1.2](https://github.com/Finschia/ostracon/tree/v1.1.2), [finschia/wasmd v0.2.0](https://github.com/Finschia/wasmd/releases/tag/v0.2.0) and [finschia/ibc-go v4.3.1](https://github.com/Finschia/ibc-go/releases/tag/v4.3.1).

### Improvements
* (improvements) #230
* (chore) #300

### Bug Fixes
* (finschia-sdk) #298

### Build, CI
* (ci) #290
* (ci) #291
