### PR TITLE
fix: change docker image version to fix build error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (repo) [\#295](https://github.com/Finschia/finschia/pull/295) setup CODEOWNERS and backport action
 * (ci) [\#296](https://github.com/Finschia/finschia/pull/296) bump actions/checkout from 3 to 4
 * (ci) [\#305](https://github.com/Finschia/finschia/pull/305) add e2e-ibc ci
-* (ci) [\#316](https://github.com/Finschia/finschia/pull/316) change docker image version to fix build error
+* (build) [\#316](https://github.com/Finschia/finschia/pull/316) change docker image version to fix build error
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (repo) [\#295](https://github.com/Finschia/finschia/pull/295) setup CODEOWNERS and backport action
 * (ci) [\#296](https://github.com/Finschia/finschia/pull/296) bump actions/checkout from 3 to 4
 * (ci) [\#305](https://github.com/Finschia/finschia/pull/305) add e2e-ibc ci
+* (ci) [\#316](https://github.com/Finschia/finschia/pull/316) change docker image version to fix build error
 
 ### Docs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 ARG GO_VERSION="1.20"
 ARG RUNNER_IMAGE="alpine:3.17"
 
-FROM golang:${GO_VERSION}-alpine AS build-env
+FROM golang:${GO_VERSION}-alpine3.17 AS build-env
 
 ARG FINSCHIA_BUILD_OPTIONS=""
 ARG GIT_VERSION

--- a/networks/local/finschianode/Dockerfile
+++ b/networks/local/finschianode/Dockerfile
@@ -7,7 +7,7 @@
 ARG GO_VERSION="1.20"
 ARG RUNNER_IMAGE="alpine:3.17"
 
-FROM golang:${GO_VERSION}-alpine AS build-env
+FROM golang:${GO_VERSION}-alpine3.17 AS build-env
 
 ARG FINSCHIA_BUILD_OPTIONS=""
 ARG GIT_VERSION


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fix the build error that occurs after bumping up the Go version from 1.18 to 1.20, caused by #241  
## Description
<!--- Describe your changes in detail -->
Without this PR, we cannot build a Docker image of Finschia.
The reason is golang:1.20-alpine is using alpine3.19, while alpine3.19 upgraded the libc version which includes the following PR: https://github.com/rust-lang/libc/pull/2935
So, this PR changes the Docker image version and sets it to golang:1.20-alpine3.17.

closes: #314 

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
You can try ```make docker-build ARCH=arm64``` or ```make docker-build``` to build docker image locally.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/finschia/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [x] I have updated the documentation accordingly.
