### PR TITLE
build: set Finschia/ostracon version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Breaking Changes
 
 ### Build, CI
+* (build) [\#340](https://github.com/Finschia/finschia/pull/340) Set Finschia/ostracon version
 
 ### Docs
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ endif
 PACKAGES_SIMTEST=$(shell go list ./... | grep '/simulation')
 SDK_PACK := $(shell go list -m github.com/Finschia/finschia-sdk | sed  's/ /\@/g')
 GO_VERSION := $(shell cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2)
-OST_VERSION := $(shell go list -m github.com/Finschia/ostracon | sed 's:.* ::') # grab everything after the space in "github.com/Finschia/ostracon v0.34.7"
+OCVERSION := $(shell go list -m github.com/Finschia/ostracon | sed 's:.* v::')
 WASMVM_VERSION=$(shell go list -m github.com/Finschia/wasmvm | awk '{print $$2}')
 HEIGHLINER_VERSION=v1.5.3
 DOCKER := $(shell which docker)
@@ -57,7 +57,7 @@ ldflags = -X github.com/Finschia/finschia-sdk/version.Name=finschia \
 		  -X github.com/Finschia/finschia-sdk/version.Commit=$(COMMIT) \
 		  -X github.com/Finschia/finschia-sdk/types.DBBackend=goleveldb \
 		  -X "github.com/Finschia/finschia-sdk/version.BuildTags=$(build_tags_comma_sep)" \
-		  -X github.com/Finschia/ostracon/version.TMCoreSemVer=$(OST_VERSION) \
+		  -X github.com/Finschia/ostracon/version.OCCoreSemVer=$(OCVERSION) \
 		  -linkmode=external \
 		  -w -s
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This patch sets Finschia/ostracon version information.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Equivalent of Finschia/finschia-sdk#1298.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. `make build`
2. `./build/fnsad ostracon version`


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/finschia/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
