### PR TITLE
chore: add fswap and fbridge swagger settings in swagger config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (build) [\#340](https://github.com/Finschia/finschia/pull/340) Set Finschia/ostracon version
 * (ci) [\#361](https://github.com/Finschia/finschia/pull/361) Replace deprecated linters with new ones
 * (ci) [\#362](https://github.com/Finschia/finschia/pull/362) Add RELEASE_NOTE.md to .gitignore
+* (swagger) [\#371](https://github.com/Finschia/finschia/pull/371) Add fswap and fbridge swagger settings in swagger config 
 
 ### Docs
 

--- a/client/docs/config.json
+++ b/client/docs/config.json
@@ -150,6 +150,24 @@
       "url": "./tmp-swagger-gen/cosmos/base/node/v1beta1/query.swagger.json"
     },
     {
+      "url": "./tmp-swagger-gen/lbm/fswap/v1/query.swagger.json"
+    },
+    {
+      "url": "./tmp-swagger-gen/lbm/fbridge/v1/query.swagger.json",
+      "operationIds": {
+        "rename": {
+          "Params": "FBridgeParams",
+          "Commitments": "FBridgeCommitments",
+          "Members": "FBridgeMembers",
+          "Member": "FBridgeMember",
+          "Proposals": "FBridgeProposals",
+          "Proposal": "FBridgeProposal",
+          "Votes": "FBridgeVotes",
+          "Vote": "FBridgeVote"
+        }
+      }
+    },
+    {
       "url": "./tmp-swagger-gen/lbm/tx/v1beta1/service.swagger.json",
       "dereference": {
         "circular": "ignore"

--- a/client/docs/swagger-ui/swagger.yaml
+++ b/client/docs/swagger-ui/swagger.yaml
@@ -29259,6 +29259,1318 @@ paths:
                       format: byte
       tags:
         - Service
+  /lbm/fswap/v1/swapped:
+    get:
+      summary: >-
+        Swapped queries the current swapped status that includes a burnt amount
+        of from-coin and a minted amount of
+
+        to-coin.
+      operationId: Swapped
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              from_coin_amount:
+                type: object
+                properties:
+                  denom:
+                    type: string
+                  amount:
+                    type: string
+                description: >-
+                  Coin defines a token with a denomination and an amount.
+
+
+                  NOTE: The amount field is an Int which implements the custom
+                  method
+
+                  signatures required by gogoproto.
+              to_coin_amount:
+                type: object
+                properties:
+                  denom:
+                    type: string
+                  amount:
+                    type: string
+                description: >-
+                  Coin defines a token with a denomination and an amount.
+
+
+                  NOTE: The amount field is an Int which implements the custom
+                  method
+
+                  signatures required by gogoproto.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      parameters:
+        - name: fromDenom
+          in: query
+          required: false
+          type: string
+        - name: toDenom
+          in: query
+          required: false
+          type: string
+      tags:
+        - Query
+  /lbm/fswap/v1/swaps:
+    get:
+      summary: Swaps queries all the swap that registered
+      operationId: Swaps
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              swaps:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    from_denom:
+                      type: string
+                    to_denom:
+                      type: string
+                    amount_cap_for_to_denom:
+                      type: string
+                    swap_rate:
+                      type: string
+              pagination:
+                type: object
+                properties:
+                  next_key:
+                    type: string
+                    format: byte
+                    title: |-
+                      next_key is the key to be passed to PageRequest.key to
+                      query the next page most efficiently
+                  total:
+                    type: string
+                    format: uint64
+                    title: >-
+                      total is total number of results available if
+                      PageRequest.count_total
+
+                      was set, its value is undefined otherwise
+                description: >-
+                  PageResponse is to be embedded in gRPC response messages where
+                  the
+
+                  corresponding request message has used PageRequest.
+
+                   message SomeResponse {
+                           repeated Bar results = 1;
+                           PageResponse page = 2;
+                   }
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      parameters:
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: >-
+            offset is a numeric offset that can be used when key is unavailable.
+
+            It is less efficient than using key. Only one of offset or key
+            should
+
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: >-
+            limit is the total number of results to be returned in the result
+            page.
+
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: >-
+            count_total is set to true  to indicate that the result set should
+            include
+
+            a count of the total number of items available for pagination in
+            UIs.
+
+            count_total is only respected when offset is used. It is ignored
+            when key
+
+            is set.
+          in: query
+          required: false
+          type: boolean
+        - name: pagination.reverse
+          description: >-
+            reverse is set to true if results are to be returned in the
+            descending order.
+
+
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Query
+  /lbm/fswap/v1/total_swappable_to_coin_amount:
+    get:
+      summary: >-
+        TotalSwappableToCoinAmount queries the current swappable amount for
+        to-coin.
+      operationId: TotalSwappableToCoinAmount
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              swappable_amount:
+                type: object
+                properties:
+                  denom:
+                    type: string
+                  amount:
+                    type: string
+                description: >-
+                  Coin defines a token with a denomination and an amount.
+
+
+                  NOTE: The amount field is an Int which implements the custom
+                  method
+
+                  signatures required by gogoproto.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      parameters:
+        - name: fromDenom
+          in: query
+          required: false
+          type: string
+        - name: toDenom
+          in: query
+          required: false
+          type: string
+      tags:
+        - Query
+  /lbm/fbridge/v1/members:
+    get:
+      summary: Members queries the members of spcific group registered on the bridge
+      operationId: FBridgeMembers
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              members:
+                type: array
+                items:
+                  type: string
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      parameters:
+        - name: role
+          description: the role name (guardian, operator, judge).
+          in: query
+          required: false
+          type: string
+      tags:
+        - Query
+  /lbm/fbridge/v1/members/{address}:
+    get:
+      summary: Member queries the role of a specific member
+      operationId: FBridgeMember
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              role:
+                type: string
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      parameters:
+        - name: address
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
+  /lbm/fbridge/v1/params:
+    get:
+      summary: Params queries the parameters of x/fbridge module.
+      operationId: FBridgeParams
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              params:
+                type: object
+                properties:
+                  operator_trust_level:
+                    description: >-
+                      ratio of how many operators' confirmations are needed to
+                      be valid.
+                    type: object
+                    properties:
+                      numerator:
+                        type: string
+                        format: uint64
+                      denominator:
+                        type: string
+                        format: uint64
+                  guardian_trust_level:
+                    description: >-
+                      ratio of how many guardians' confirmations are needed to
+                      be valid.
+                    type: object
+                    properties:
+                      numerator:
+                        type: string
+                        format: uint64
+                      denominator:
+                        type: string
+                        format: uint64
+                  judge_trust_level:
+                    description: >-
+                      ratio of how many judges' confirmations are needed to be
+                      valid.
+                    type: object
+                    properties:
+                      numerator:
+                        type: string
+                        format: uint64
+                      denominator:
+                        type: string
+                        format: uint64
+                  timelock_period:
+                    type: string
+                    format: uint64
+                    title: >-
+                      default timelock period for each provision (unix
+                      timestamp)
+                  proposal_period:
+                    type: string
+                    format: uint64
+                    title: default period of the proposal to update the role
+                  target_denom:
+                    type: string
+                    description: >-
+                      target denom of the bridge module. This is the base denom
+                      of Finschia normally.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      tags:
+        - Query
+  /lbm/fbridge/v1/proposals:
+    get:
+      summary: Proposals queries a list of SuggestRole Proposals
+      operationId: FBridgeProposals
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              proposals:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      format: uint64
+                    proposer:
+                      type: string
+                      title: the proposer address
+                    target:
+                      type: string
+                      title: the address to update the role
+                    role:
+                      title: >-
+                        the role to be updated
+
+                        - unspecified : 0, used to remove the address from a
+                        group
+
+                        - guardian : 1
+
+                        - operator : 2
+
+                        - judge : 3
+                      type: string
+                      enum:
+                        - UNSPECIFIED
+                        - GUARDIAN
+                        - OPERATOR
+                        - JUDGE
+                      default: UNSPECIFIED
+                      description: >-
+                        Role defines the role of the operator, guardian, and
+                        judge.
+                    expired_at:
+                      type: string
+                      format: date-time
+                      title: >-
+                        the unix timestamp the proposal will be expired (unix
+                        timestamp)
+              pagination:
+                description: pagination defines an pagination for the response.
+                type: object
+                properties:
+                  next_key:
+                    type: string
+                    format: byte
+                    title: |-
+                      next_key is the key to be passed to PageRequest.key to
+                      query the next page most efficiently
+                  total:
+                    type: string
+                    format: uint64
+                    title: >-
+                      total is total number of results available if
+                      PageRequest.count_total
+
+                      was set, its value is undefined otherwise
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      parameters:
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: >-
+            offset is a numeric offset that can be used when key is unavailable.
+
+            It is less efficient than using key. Only one of offset or key
+            should
+
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: >-
+            limit is the total number of results to be returned in the result
+            page.
+
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: >-
+            count_total is set to true  to indicate that the result set should
+            include
+
+            a count of the total number of items available for pagination in
+            UIs.
+
+            count_total is only respected when offset is used. It is ignored
+            when key
+
+            is set.
+          in: query
+          required: false
+          type: boolean
+        - name: pagination.reverse
+          description: >-
+            reverse is set to true if results are to be returned in the
+            descending order.
+
+
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Query
+  /lbm/fbridge/v1/proposals/{proposal_id}:
+    get:
+      summary: Proposal queries a SuggestRole Proposal
+      operationId: FBridgeProposal
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              proposal:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uint64
+                  proposer:
+                    type: string
+                    title: the proposer address
+                  target:
+                    type: string
+                    title: the address to update the role
+                  role:
+                    title: |-
+                      the role to be updated
+                      - unspecified : 0, used to remove the address from a group
+                      - guardian : 1
+                      - operator : 2
+                      - judge : 3
+                    type: string
+                    enum:
+                      - UNSPECIFIED
+                      - GUARDIAN
+                      - OPERATOR
+                      - JUDGE
+                    default: UNSPECIFIED
+                    description: >-
+                      Role defines the role of the operator, guardian, and
+                      judge.
+                  expired_at:
+                    type: string
+                    format: date-time
+                    title: >-
+                      the unix timestamp the proposal will be expired (unix
+                      timestamp)
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      parameters:
+        - name: proposal_id
+          description: the proposal id
+          in: path
+          required: true
+          type: string
+          format: uint64
+      tags:
+        - Query
+  /lbm/fbridge/v1/proposals/{proposal_id}/votes:
+    get:
+      summary: Votes queries votes of a given proposal.
+      operationId: FBridgeVotes
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              votes:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    proposal_id:
+                      type: string
+                      format: uint64
+                    voter:
+                      type: string
+                    option:
+                      type: string
+                      enum:
+                        - VOTE_OPTION_UNSPECIFIED
+                        - VOTE_OPTION_YES
+                        - VOTE_OPTION_NO
+                      default: VOTE_OPTION_UNSPECIFIED
+                      description: >-
+                        VoteOption enumerates the valid vote options for a given
+                        role proposal.
+
+                         - VOTE_OPTION_UNSPECIFIED: VOTE_OPTION_UNSPECIFIED defines a no-op vote option.
+                         - VOTE_OPTION_YES: VOTE_OPTION_YES defines a yes vote option.
+                         - VOTE_OPTION_NO: VOTE_OPTION_NO defines a no vote option.
+                  description: Vote defines a vote on a role proposal.
+                description: votes defined the queried votes.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      parameters:
+        - name: proposal_id
+          description: proposal_id defines the unique id of the proposal.
+          in: path
+          required: true
+          type: string
+          format: uint64
+      tags:
+        - Query
+  /lbm/fbridge/v1/proposals/{proposal_id}/votes/{voter}:
+    get:
+      summary: Vote queries voted information based on proposalID, voterAddr.
+      operationId: FBridgeVote
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              vote:
+                type: object
+                properties:
+                  proposal_id:
+                    type: string
+                    format: uint64
+                  voter:
+                    type: string
+                  option:
+                    type: string
+                    enum:
+                      - VOTE_OPTION_UNSPECIFIED
+                      - VOTE_OPTION_YES
+                      - VOTE_OPTION_NO
+                    default: VOTE_OPTION_UNSPECIFIED
+                    description: >-
+                      VoteOption enumerates the valid vote options for a given
+                      role proposal.
+
+                       - VOTE_OPTION_UNSPECIFIED: VOTE_OPTION_UNSPECIFIED defines a no-op vote option.
+                       - VOTE_OPTION_YES: VOTE_OPTION_YES defines a yes vote option.
+                       - VOTE_OPTION_NO: VOTE_OPTION_NO defines a no vote option.
+                description: Vote defines a vote on a role proposal.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      parameters:
+        - name: proposal_id
+          description: proposal_id defines the unique id of the proposal.
+          in: path
+          required: true
+          type: string
+          format: uint64
+        - name: voter
+          description: voter defines the oter address for the proposals.
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
+  /lbm/fbridge/v1/receiving/commitments/{seq}:
+    get:
+      summary: Commitments queries commitments of a specific sequence number
+      operationId: FBridgeCommitments
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              commitments:
+                type: array
+                items:
+                  type: string
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      parameters:
+        - name: seq
+          description: the sequence number of the bridge request
+          in: path
+          required: true
+          type: string
+          format: uint64
+      tags:
+        - Query
+  /lbm/fbridge/v1/receiving/greatest_confirmed_seq:
+    get:
+      summary: >-
+        GreatestConsecutiveConfirmedSeq queries a greatest consecutive sequence
+        number confirmed by n-of-m operators
+      operationId: GreatestConsecutiveConfirmedSeq
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              seq:
+                type: string
+                format: uint64
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      tags:
+        - Query
+  /lbm/fbridge/v1/receiving/operators/{operator}/needed_submission_seqs:
+    get:
+      summary: >-
+        NeededSubmissionSeqs queries a list of sequence numbers that need to be
+        submitted by a particular operator
+
+        The search scope is [greatest_consecutive_seq_by_operator,
+        min(greatest_consecutive_seq_by_operator + range,
+
+        greatest_seq_by_operator)] greatest_consecutive_seq_by_operator can be
+        replaced with greatest_consecutive_seq if
+
+        the operator is newly added
+      operationId: NeededSubmissionSeqs
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              seqs:
+                type: array
+                items:
+                  type: string
+                  format: uint64
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      parameters:
+        - name: operator
+          description: the address of the operator
+          in: path
+          required: true
+          type: string
+        - name: range
+          description: range specifies the size of the range to search.
+          in: query
+          required: false
+          type: string
+          format: uint64
+      tags:
+        - Query
+  /lbm/fbridge/v1/receiving/operators/{operator}/provision/{seq}:
+    get:
+      summary: >-
+        SubmittedProvision queries a provision submitted by a particular
+        operator
+      operationId: SubmittedProvision
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              data:
+                type: object
+                properties:
+                  seq:
+                    type: string
+                    format: uint64
+                    title: the sequence number of the bridge request
+                  amount:
+                    type: string
+                    title: the amount of token to be claimed
+                  sender:
+                    type: string
+                    title: the sender address on the source chain
+                  receiver:
+                    type: string
+                    title: the recipient address on the destination chain
+                description: Provision is a struct that represents a provision internally.
+              status:
+                type: object
+                properties:
+                  timelock_end:
+                    type: string
+                    format: uint64
+                    title: >-
+                      the unix timestamp the provision will be able to be
+                      claimed (unix timestamp)
+                  confirm_counts:
+                    type: integer
+                    format: int32
+                    title: >-
+                      a value that tells how many operators have submitted this
+                      provision
+                  is_claimed:
+                    type: boolean
+                    title: whether the provision has been claimed
+                description: >-
+                  ProvisionStatus is a struct that represents the status of a
+                  provision.
+
+                  To optimize computational cost, we have collected frequently
+                  changing values from provision.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      parameters:
+        - name: operator
+          description: the address of the operator
+          in: path
+          required: true
+          type: string
+        - name: seq
+          description: the sequence number of the bridge request
+          in: path
+          required: true
+          type: string
+          format: uint64
+      tags:
+        - Query
+  /lbm/fbridge/v1/receiving/operators/{operator}/seq:
+    get:
+      summary: >-
+        GreatestSeqByOperator queries a greatest sequence number confirmed by a
+        particular operator
+      operationId: GreatestSeqByOperator
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              seq:
+                type: string
+                format: uint64
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      parameters:
+        - name: operator
+          description: the address of the operator
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
+  /lbm/fbridge/v1/receiving/provision/{seq}:
+    get:
+      summary: ConfirmedProvision queries a particular sequence of confirmed provisions
+      operationId: ConfirmedProvision
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              data:
+                type: object
+                properties:
+                  seq:
+                    type: string
+                    format: uint64
+                    title: the sequence number of the bridge request
+                  amount:
+                    type: string
+                    title: the amount of token to be claimed
+                  sender:
+                    type: string
+                    title: the sender address on the source chain
+                  receiver:
+                    type: string
+                    title: the recipient address on the destination chain
+                description: Provision is a struct that represents a provision internally.
+              status:
+                type: object
+                properties:
+                  timelock_end:
+                    type: string
+                    format: uint64
+                    title: >-
+                      the unix timestamp the provision will be able to be
+                      claimed (unix timestamp)
+                  confirm_counts:
+                    type: integer
+                    format: int32
+                    title: >-
+                      a value that tells how many operators have submitted this
+                      provision
+                  is_claimed:
+                    type: boolean
+                    title: whether the provision has been claimed
+                description: >-
+                  ProvisionStatus is a struct that represents the status of a
+                  provision.
+
+                  To optimize computational cost, we have collected frequently
+                  changing values from provision.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      parameters:
+        - name: seq
+          description: the sequence number of the bridge request
+          in: path
+          required: true
+          type: string
+          format: uint64
+      tags:
+        - Query
+  /lbm/fbridge/v1/sending/blocknums:
+    get:
+      summary: >-
+        BlocknumToSeqs queries a list of block numbers for which each sequence
+        has been confirmed.
+      operationId: SeqToBlocknums
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              blocknums:
+                type: array
+                items:
+                  type: string
+                  format: uint64
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      parameters:
+        - name: seqs
+          description: list of sequence number of the bridge request.
+          in: query
+          required: false
+          type: array
+          items:
+            type: string
+            format: uint64
+          collectionFormat: multi
+      tags:
+        - Query
+  /lbm/fbridge/v1/sending/nextseq:
+    get:
+      summary: NextSeqSend queries the sequence of next bridge request
+      operationId: NextSeqSend
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              seq:
+                type: string
+                format: uint64
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      tags:
+        - Query
+  /lbm/fbridge/v1/status:
+    get:
+      summary: BridgeStatus queries the status of the bridge
+      operationId: BridgeStatus
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+                enum:
+                  - BRIDGE_STATUS_UNSPECIFIED
+                  - BRIDGE_STATUS_ACTIVE
+                  - BRIDGE_STATUS_INACTIVE
+                default: BRIDGE_STATUS_UNSPECIFIED
+                description: |2-
+                   - BRIDGE_STATUS_UNSPECIFIED: BRIDGE_STATUS_UNSPECIFIED defines an unspecified bridge status.
+                   - BRIDGE_STATUS_ACTIVE: BRIDGE_STATUS_ACTIVE defines an active bridge status.
+                   - BRIDGE_STATUS_INACTIVE: BRIDGE_STATUS_INACTIVE defines an inactive bridge status.
+              metadata:
+                type: object
+                properties:
+                  inactive:
+                    type: string
+                    format: uint64
+                    title: the number of inactived bridge switch
+                  active:
+                    type: string
+                    format: uint64
+                    title: the number of activated bridge switch
+                description: >-
+                  BridgeStatusMetadata defines the metadata of the bridge
+                  status.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                    value:
+                      type: string
+                      format: byte
+      tags:
+        - Query
   /lbm/tx/v1beta1/txs/block/{height}:
     get:
       summary: GetBlockWithTxs fetches a block with decoded txs.
@@ -64759,6 +66071,652 @@ definitions:
       minimum_gas_price:
         type: string
     description: ConfigResponse defines the response structure for the Config gRPC query.
+  lbm.fswap.v1.QuerySwappedResponse:
+    type: object
+    properties:
+      from_coin_amount:
+        type: object
+        properties:
+          denom:
+            type: string
+          amount:
+            type: string
+        description: |-
+          Coin defines a token with a denomination and an amount.
+
+          NOTE: The amount field is an Int which implements the custom method
+          signatures required by gogoproto.
+      to_coin_amount:
+        type: object
+        properties:
+          denom:
+            type: string
+          amount:
+            type: string
+        description: |-
+          Coin defines a token with a denomination and an amount.
+
+          NOTE: The amount field is an Int which implements the custom method
+          signatures required by gogoproto.
+  lbm.fswap.v1.QuerySwapsResponse:
+    type: object
+    properties:
+      swaps:
+        type: array
+        items:
+          type: object
+          properties:
+            from_denom:
+              type: string
+            to_denom:
+              type: string
+            amount_cap_for_to_denom:
+              type: string
+            swap_rate:
+              type: string
+      pagination:
+        type: object
+        properties:
+          next_key:
+            type: string
+            format: byte
+            title: |-
+              next_key is the key to be passed to PageRequest.key to
+              query the next page most efficiently
+          total:
+            type: string
+            format: uint64
+            title: >-
+              total is total number of results available if
+              PageRequest.count_total
+
+              was set, its value is undefined otherwise
+        description: |-
+          PageResponse is to be embedded in gRPC response messages where the
+          corresponding request message has used PageRequest.
+
+           message SomeResponse {
+                   repeated Bar results = 1;
+                   PageResponse page = 2;
+           }
+  lbm.fswap.v1.QueryTotalSwappableToCoinAmountResponse:
+    type: object
+    properties:
+      swappable_amount:
+        type: object
+        properties:
+          denom:
+            type: string
+          amount:
+            type: string
+        description: |-
+          Coin defines a token with a denomination and an amount.
+
+          NOTE: The amount field is an Int which implements the custom method
+          signatures required by gogoproto.
+  lbm.fswap.v1.Swap:
+    type: object
+    properties:
+      from_denom:
+        type: string
+      to_denom:
+        type: string
+      amount_cap_for_to_denom:
+        type: string
+      swap_rate:
+        type: string
+  lbm.fbridge.v1.BridgeStatus:
+    type: string
+    enum:
+      - BRIDGE_STATUS_UNSPECIFIED
+      - BRIDGE_STATUS_ACTIVE
+      - BRIDGE_STATUS_INACTIVE
+    default: BRIDGE_STATUS_UNSPECIFIED
+    description: |2-
+       - BRIDGE_STATUS_UNSPECIFIED: BRIDGE_STATUS_UNSPECIFIED defines an unspecified bridge status.
+       - BRIDGE_STATUS_ACTIVE: BRIDGE_STATUS_ACTIVE defines an active bridge status.
+       - BRIDGE_STATUS_INACTIVE: BRIDGE_STATUS_INACTIVE defines an inactive bridge status.
+  lbm.fbridge.v1.BridgeStatusMetadata:
+    type: object
+    properties:
+      inactive:
+        type: string
+        format: uint64
+        title: the number of inactived bridge switch
+      active:
+        type: string
+        format: uint64
+        title: the number of activated bridge switch
+    description: BridgeStatusMetadata defines the metadata of the bridge status.
+  lbm.fbridge.v1.Fraction:
+    type: object
+    properties:
+      numerator:
+        type: string
+        format: uint64
+      denominator:
+        type: string
+        format: uint64
+    description: |-
+      Fraction defines the protobuf message type for tmmath.Fraction that only
+      supports positive values.
+  lbm.fbridge.v1.Params:
+    type: object
+    properties:
+      operator_trust_level:
+        description: ratio of how many operators' confirmations are needed to be valid.
+        type: object
+        properties:
+          numerator:
+            type: string
+            format: uint64
+          denominator:
+            type: string
+            format: uint64
+      guardian_trust_level:
+        description: ratio of how many guardians' confirmations are needed to be valid.
+        type: object
+        properties:
+          numerator:
+            type: string
+            format: uint64
+          denominator:
+            type: string
+            format: uint64
+      judge_trust_level:
+        description: ratio of how many judges' confirmations are needed to be valid.
+        type: object
+        properties:
+          numerator:
+            type: string
+            format: uint64
+          denominator:
+            type: string
+            format: uint64
+      timelock_period:
+        type: string
+        format: uint64
+        title: default timelock period for each provision (unix timestamp)
+      proposal_period:
+        type: string
+        format: uint64
+        title: default period of the proposal to update the role
+      target_denom:
+        type: string
+        description: >-
+          target denom of the bridge module. This is the base denom of Finschia
+          normally.
+  lbm.fbridge.v1.ProvisionData:
+    type: object
+    properties:
+      seq:
+        type: string
+        format: uint64
+        title: the sequence number of the bridge request
+      amount:
+        type: string
+        title: the amount of token to be claimed
+      sender:
+        type: string
+        title: the sender address on the source chain
+      receiver:
+        type: string
+        title: the recipient address on the destination chain
+    description: Provision is a struct that represents a provision internally.
+  lbm.fbridge.v1.ProvisionStatus:
+    type: object
+    properties:
+      timelock_end:
+        type: string
+        format: uint64
+        title: >-
+          the unix timestamp the provision will be able to be claimed (unix
+          timestamp)
+      confirm_counts:
+        type: integer
+        format: int32
+        title: a value that tells how many operators have submitted this provision
+      is_claimed:
+        type: boolean
+        title: whether the provision has been claimed
+    description: >-
+      ProvisionStatus is a struct that represents the status of a provision.
+
+      To optimize computational cost, we have collected frequently changing
+      values from provision.
+  lbm.fbridge.v1.QueryBridgeStatusResponse:
+    type: object
+    properties:
+      status:
+        type: string
+        enum:
+          - BRIDGE_STATUS_UNSPECIFIED
+          - BRIDGE_STATUS_ACTIVE
+          - BRIDGE_STATUS_INACTIVE
+        default: BRIDGE_STATUS_UNSPECIFIED
+        description: |2-
+           - BRIDGE_STATUS_UNSPECIFIED: BRIDGE_STATUS_UNSPECIFIED defines an unspecified bridge status.
+           - BRIDGE_STATUS_ACTIVE: BRIDGE_STATUS_ACTIVE defines an active bridge status.
+           - BRIDGE_STATUS_INACTIVE: BRIDGE_STATUS_INACTIVE defines an inactive bridge status.
+      metadata:
+        type: object
+        properties:
+          inactive:
+            type: string
+            format: uint64
+            title: the number of inactived bridge switch
+          active:
+            type: string
+            format: uint64
+            title: the number of activated bridge switch
+        description: BridgeStatusMetadata defines the metadata of the bridge status.
+  lbm.fbridge.v1.QueryCommitmentsResponse:
+    type: object
+    properties:
+      commitments:
+        type: array
+        items:
+          type: string
+  lbm.fbridge.v1.QueryConfirmedProvisionResponse:
+    type: object
+    properties:
+      data:
+        type: object
+        properties:
+          seq:
+            type: string
+            format: uint64
+            title: the sequence number of the bridge request
+          amount:
+            type: string
+            title: the amount of token to be claimed
+          sender:
+            type: string
+            title: the sender address on the source chain
+          receiver:
+            type: string
+            title: the recipient address on the destination chain
+        description: Provision is a struct that represents a provision internally.
+      status:
+        type: object
+        properties:
+          timelock_end:
+            type: string
+            format: uint64
+            title: >-
+              the unix timestamp the provision will be able to be claimed (unix
+              timestamp)
+          confirm_counts:
+            type: integer
+            format: int32
+            title: >-
+              a value that tells how many operators have submitted this
+              provision
+          is_claimed:
+            type: boolean
+            title: whether the provision has been claimed
+        description: >-
+          ProvisionStatus is a struct that represents the status of a provision.
+
+          To optimize computational cost, we have collected frequently changing
+          values from provision.
+  lbm.fbridge.v1.QueryGreatestConsecutiveConfirmedSeqResponse:
+    type: object
+    properties:
+      seq:
+        type: string
+        format: uint64
+  lbm.fbridge.v1.QueryGreatestSeqByOperatorResponse:
+    type: object
+    properties:
+      seq:
+        type: string
+        format: uint64
+  lbm.fbridge.v1.QueryMemberResponse:
+    type: object
+    properties:
+      role:
+        type: string
+  lbm.fbridge.v1.QueryMembersResponse:
+    type: object
+    properties:
+      members:
+        type: array
+        items:
+          type: string
+  lbm.fbridge.v1.QueryNeededSubmissionSeqsResponse:
+    type: object
+    properties:
+      seqs:
+        type: array
+        items:
+          type: string
+          format: uint64
+  lbm.fbridge.v1.QueryNextSeqSendResponse:
+    type: object
+    properties:
+      seq:
+        type: string
+        format: uint64
+  lbm.fbridge.v1.QueryParamsResponse:
+    type: object
+    properties:
+      params:
+        type: object
+        properties:
+          operator_trust_level:
+            description: ratio of how many operators' confirmations are needed to be valid.
+            type: object
+            properties:
+              numerator:
+                type: string
+                format: uint64
+              denominator:
+                type: string
+                format: uint64
+          guardian_trust_level:
+            description: ratio of how many guardians' confirmations are needed to be valid.
+            type: object
+            properties:
+              numerator:
+                type: string
+                format: uint64
+              denominator:
+                type: string
+                format: uint64
+          judge_trust_level:
+            description: ratio of how many judges' confirmations are needed to be valid.
+            type: object
+            properties:
+              numerator:
+                type: string
+                format: uint64
+              denominator:
+                type: string
+                format: uint64
+          timelock_period:
+            type: string
+            format: uint64
+            title: default timelock period for each provision (unix timestamp)
+          proposal_period:
+            type: string
+            format: uint64
+            title: default period of the proposal to update the role
+          target_denom:
+            type: string
+            description: >-
+              target denom of the bridge module. This is the base denom of
+              Finschia normally.
+  lbm.fbridge.v1.QueryProposalResponse:
+    type: object
+    properties:
+      proposal:
+        type: object
+        properties:
+          id:
+            type: string
+            format: uint64
+          proposer:
+            type: string
+            title: the proposer address
+          target:
+            type: string
+            title: the address to update the role
+          role:
+            title: |-
+              the role to be updated
+              - unspecified : 0, used to remove the address from a group
+              - guardian : 1
+              - operator : 2
+              - judge : 3
+            type: string
+            enum:
+              - UNSPECIFIED
+              - GUARDIAN
+              - OPERATOR
+              - JUDGE
+            default: UNSPECIFIED
+            description: Role defines the role of the operator, guardian, and judge.
+          expired_at:
+            type: string
+            format: date-time
+            title: the unix timestamp the proposal will be expired (unix timestamp)
+  lbm.fbridge.v1.QueryProposalsResponse:
+    type: object
+    properties:
+      proposals:
+        type: array
+        items:
+          type: object
+          properties:
+            id:
+              type: string
+              format: uint64
+            proposer:
+              type: string
+              title: the proposer address
+            target:
+              type: string
+              title: the address to update the role
+            role:
+              title: |-
+                the role to be updated
+                - unspecified : 0, used to remove the address from a group
+                - guardian : 1
+                - operator : 2
+                - judge : 3
+              type: string
+              enum:
+                - UNSPECIFIED
+                - GUARDIAN
+                - OPERATOR
+                - JUDGE
+              default: UNSPECIFIED
+              description: Role defines the role of the operator, guardian, and judge.
+            expired_at:
+              type: string
+              format: date-time
+              title: the unix timestamp the proposal will be expired (unix timestamp)
+      pagination:
+        description: pagination defines an pagination for the response.
+        type: object
+        properties:
+          next_key:
+            type: string
+            format: byte
+            title: |-
+              next_key is the key to be passed to PageRequest.key to
+              query the next page most efficiently
+          total:
+            type: string
+            format: uint64
+            title: >-
+              total is total number of results available if
+              PageRequest.count_total
+
+              was set, its value is undefined otherwise
+  lbm.fbridge.v1.QuerySeqToBlocknumsResponse:
+    type: object
+    properties:
+      blocknums:
+        type: array
+        items:
+          type: string
+          format: uint64
+  lbm.fbridge.v1.QuerySubmittedProvisionResponse:
+    type: object
+    properties:
+      data:
+        type: object
+        properties:
+          seq:
+            type: string
+            format: uint64
+            title: the sequence number of the bridge request
+          amount:
+            type: string
+            title: the amount of token to be claimed
+          sender:
+            type: string
+            title: the sender address on the source chain
+          receiver:
+            type: string
+            title: the recipient address on the destination chain
+        description: Provision is a struct that represents a provision internally.
+      status:
+        type: object
+        properties:
+          timelock_end:
+            type: string
+            format: uint64
+            title: >-
+              the unix timestamp the provision will be able to be claimed (unix
+              timestamp)
+          confirm_counts:
+            type: integer
+            format: int32
+            title: >-
+              a value that tells how many operators have submitted this
+              provision
+          is_claimed:
+            type: boolean
+            title: whether the provision has been claimed
+        description: >-
+          ProvisionStatus is a struct that represents the status of a provision.
+
+          To optimize computational cost, we have collected frequently changing
+          values from provision.
+  lbm.fbridge.v1.QueryVoteResponse:
+    type: object
+    properties:
+      vote:
+        type: object
+        properties:
+          proposal_id:
+            type: string
+            format: uint64
+          voter:
+            type: string
+          option:
+            type: string
+            enum:
+              - VOTE_OPTION_UNSPECIFIED
+              - VOTE_OPTION_YES
+              - VOTE_OPTION_NO
+            default: VOTE_OPTION_UNSPECIFIED
+            description: >-
+              VoteOption enumerates the valid vote options for a given role
+              proposal.
+
+               - VOTE_OPTION_UNSPECIFIED: VOTE_OPTION_UNSPECIFIED defines a no-op vote option.
+               - VOTE_OPTION_YES: VOTE_OPTION_YES defines a yes vote option.
+               - VOTE_OPTION_NO: VOTE_OPTION_NO defines a no vote option.
+        description: Vote defines a vote on a role proposal.
+  lbm.fbridge.v1.QueryVotesResponse:
+    type: object
+    properties:
+      votes:
+        type: array
+        items:
+          type: object
+          properties:
+            proposal_id:
+              type: string
+              format: uint64
+            voter:
+              type: string
+            option:
+              type: string
+              enum:
+                - VOTE_OPTION_UNSPECIFIED
+                - VOTE_OPTION_YES
+                - VOTE_OPTION_NO
+              default: VOTE_OPTION_UNSPECIFIED
+              description: >-
+                VoteOption enumerates the valid vote options for a given role
+                proposal.
+
+                 - VOTE_OPTION_UNSPECIFIED: VOTE_OPTION_UNSPECIFIED defines a no-op vote option.
+                 - VOTE_OPTION_YES: VOTE_OPTION_YES defines a yes vote option.
+                 - VOTE_OPTION_NO: VOTE_OPTION_NO defines a no vote option.
+          description: Vote defines a vote on a role proposal.
+        description: votes defined the queried votes.
+  lbm.fbridge.v1.Role:
+    type: string
+    enum:
+      - UNSPECIFIED
+      - GUARDIAN
+      - OPERATOR
+      - JUDGE
+    default: UNSPECIFIED
+    description: Role defines the role of the operator, guardian, and judge.
+  lbm.fbridge.v1.RoleProposal:
+    type: object
+    properties:
+      id:
+        type: string
+        format: uint64
+      proposer:
+        type: string
+        title: the proposer address
+      target:
+        type: string
+        title: the address to update the role
+      role:
+        title: |-
+          the role to be updated
+          - unspecified : 0, used to remove the address from a group
+          - guardian : 1
+          - operator : 2
+          - judge : 3
+        type: string
+        enum:
+          - UNSPECIFIED
+          - GUARDIAN
+          - OPERATOR
+          - JUDGE
+        default: UNSPECIFIED
+        description: Role defines the role of the operator, guardian, and judge.
+      expired_at:
+        type: string
+        format: date-time
+        title: the unix timestamp the proposal will be expired (unix timestamp)
+  lbm.fbridge.v1.Vote:
+    type: object
+    properties:
+      proposal_id:
+        type: string
+        format: uint64
+      voter:
+        type: string
+      option:
+        type: string
+        enum:
+          - VOTE_OPTION_UNSPECIFIED
+          - VOTE_OPTION_YES
+          - VOTE_OPTION_NO
+        default: VOTE_OPTION_UNSPECIFIED
+        description: >-
+          VoteOption enumerates the valid vote options for a given role
+          proposal.
+
+           - VOTE_OPTION_UNSPECIFIED: VOTE_OPTION_UNSPECIFIED defines a no-op vote option.
+           - VOTE_OPTION_YES: VOTE_OPTION_YES defines a yes vote option.
+           - VOTE_OPTION_NO: VOTE_OPTION_NO defines a no vote option.
+    description: Vote defines a vote on a role proposal.
+  lbm.fbridge.v1.VoteOption:
+    type: string
+    enum:
+      - VOTE_OPTION_UNSPECIFIED
+      - VOTE_OPTION_YES
+      - VOTE_OPTION_NO
+    default: VOTE_OPTION_UNSPECIFIED
+    description: |-
+      VoteOption enumerates the valid vote options for a given role proposal.
+
+       - VOTE_OPTION_UNSPECIFIED: VOTE_OPTION_UNSPECIFIED defines a no-op vote option.
+       - VOTE_OPTION_YES: VOTE_OPTION_YES defines a yes vote option.
+       - VOTE_OPTION_NO: VOTE_OPTION_NO defines a no vote option.
   lbm.tx.v1beta1.GetBlockWithTxsResponse:
     type: object
     properties:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* add fswap and fbridge swagger settings in swagger config 

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* The queries of fswap and fbridge module are not displayed in swagger. 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. make install
2. set default single node setting. `./init_single.sh`
3. change app.toml setting for enable swagger.  `enable` and `swagger` of `[api]` section set `true`.
4. `fnsad start`
5. view http://localhost:1317/swagger/

<img width="1369" alt="스크린샷 2024-05-12 오전 11 44 43" src="https://github.com/Finschia/finschia/assets/3938725/3f8cdb39-012d-49c9-9fd6-727ea503188d">


## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/finschia/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
