### PR TITLE
feat: Force user to follow the rule of release note generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (fswap, fbridge) [\#380](https://github.com/Finschia/finschia/pull/380) Bump github.com/Finschia/finschia-sdk from v0.49.0-rc6 to v0.49.0-rc7
 
 ### Improvements
+* (ci) [\#385](https://github.com/Finschia/finschia/pull/385) Force user to follow the rule of release note generation
 
 ### Bug Fixes
 

--- a/RELEASE_DESCR.md
+++ b/RELEASE_DESCR.md
@@ -40,3 +40,5 @@ This version based on finschia-sdk v0.46.0-rc2
 
 ## [v0.1.0] - 2021-11-01
 This is the first release of the Finschia blockchain. It is based on [gaia v4.0.4](https://github.com/cosmos/gaia/releases/tag/v4.0.4).
+
+<!-- Release links -->

--- a/scripts/release-note.py
+++ b/scripts/release-note.py
@@ -28,8 +28,12 @@ def get_prev_gittag(target_tag: str) -> str:
         )
 
 
-def extract_package_version(document: str, package_name: str):
-    pattern = rf"{re.escape(package_name)} (v[^\s]+)"
+def extract_package_version(
+    document: str, package_name: str, version_suffix: bool
+) -> str:
+    suffix_pattern = r"\/v\d+" if version_suffix else ""
+    pattern = rf"{re.escape(package_name)}{suffix_pattern} (v[^\s]+)"
+
     match = re.search(pattern, document)
     if match:
         return match.group(1)
@@ -37,7 +41,7 @@ def extract_package_version(document: str, package_name: str):
         raise ValueError(f"Package {package_name} not found in the document.")
 
 
-def extract_go_version(document: str):
+def extract_go_version(document: str) -> str:
     pattern = r"go ([^\s]+)"
     match = re.search(pattern, document)
     if match:
@@ -52,25 +56,29 @@ def extract_release_contents(target: str, cur_tag: str, prev_tag: str) -> str:
 
     with open(target, "r") as f:
         document = f.read()
-    start_marker = f"## [{cur_tag}]"
-    start_pos = document.find(start_marker) + len(start_marker) + len(" - YYYY-MM-DD")
-    if start_pos != -1:
-        if prev_tag is None:
-            end_pos = document.find("<!-- Release links -->")
-            if end_pos == -1:
-                match = re.search(r"## \[v\d+\.\d+\.\d+] - \d{4}-\d{2}-\d{2}", document[start_pos:])
-                if match is None:
-                    end_pos = -1
-                else:
-                    end_pos = start_pos + match.start() - 1
-        else:
-            end_marker = f"## [{prev_tag}]"
-            end_pos = document.find(end_marker)
-            if end_pos == -1:
-                match = re.search(r"## \[v\d+\.\d+\.\d+] - \d{4}-\d{2}-\d{2}", document[start_pos:])
-                end_pos = start_pos + match.start() - 1
+
+    start_marker = f"## [{cur_tag}] - "
+    start_pos = document.find(start_marker)
+
+    if start_pos == -1:
+        raise ValueError(f"Start marker for tag '{cur_tag}' not found in the document.")
+
+    start_pos += len(start_marker) + len("YYYY-MM-DD")
+
+    if prev_tag:
+        end_marker = f"## [{prev_tag}]"
+        end_pos = document.find(end_marker, start_pos)
+        if end_pos == -1:
+            raise ValueError(
+                f"End marker for previous tag '{prev_tag}' not found in the document."
+            )
     else:
-        raise ValueError("Content not found between the specified markers.")
+        end_pos = document.find("<!-- Release links -->", start_pos)
+        if end_pos == -1:
+            raise ValueError(
+                "End marker '<!-- Release links -->' not found in the document."
+            )
+
     return document[start_pos:end_pos].strip()
 
 
@@ -85,10 +93,12 @@ if len(args) != 1:
 TAG = args[0]
 PREV_TAG = get_prev_gittag(TAG)
 GO_VERSION = extract_go_version(gomod)
-OSTRACON_VERSION = extract_package_version(gomod, "github.com/Finschia/ostracon")
-FNSASDK_VERSION = extract_package_version(gomod, "github.com/Finschia/finschia-sdk")
-WASMD_VERSION = extract_package_version(gomod, "github.com/Finschia/wasmd")
-IBC_VERSION = extract_package_version(gomod, "github.com/cosmos/ibc-go/v4")
+OSTRACON_VERSION = extract_package_version(gomod, "github.com/Finschia/ostracon", False)
+FNSASDK_VERSION = extract_package_version(
+    gomod, "github.com/Finschia/finschia-sdk", False
+)
+WASMD_VERSION = extract_package_version(gomod, "github.com/Finschia/wasmd", False)
+IBC_VERSION = extract_package_version(gomod, "github.com/cosmos/ibc-go", True)
 
 release_note = f"""# Finschia {TAG} Release Note
 

--- a/scripts/release-note.py
+++ b/scripts/release-note.py
@@ -61,21 +61,18 @@ def extract_release_contents(target: str, cur_tag: str, prev_tag: str) -> str:
     start_pos = document.find(start_marker)
 
     if start_pos == -1:
-        raise ValueError(f"Start marker for tag '{cur_tag}' not found in {target}.")
+        raise ValueError(f"Start marker for tag '{cur_tag}' not found in {target}")
 
     start_pos += len(start_marker) + len("YYYY-MM-DD")
     end_marker = f"## [{prev_tag}]" if prev_tag else "<!-- Release links -->"
+    end_pos = document.find(end_marker, start_pos)
 
-    if prev_tag:
-        end_pos = document.find(end_marker, start_pos)
-        if end_pos == -1:
-            raise ValueError(
-                f"End marker for previous tag '{prev_tag}' not found in {target}."
-            )
-    else:
-        end_pos = document.find(end_marker, start_pos)
-        if end_pos == -1:
-            raise ValueError(f"End marker '{end_marker}' not found in {target}.")
+    if end_pos == -1:
+        raise ValueError(
+            f"End marker for previous tag '{prev_tag}' not found in {target}"
+            if prev_tag
+            else f"End marker '{end_marker}' not found in {target}"
+        )
 
     return document[start_pos:end_pos].strip()
 

--- a/scripts/release-note.py
+++ b/scripts/release-note.py
@@ -61,23 +61,21 @@ def extract_release_contents(target: str, cur_tag: str, prev_tag: str) -> str:
     start_pos = document.find(start_marker)
 
     if start_pos == -1:
-        raise ValueError(f"Start marker for tag '{cur_tag}' not found in the document.")
+        raise ValueError(f"Start marker for tag '{cur_tag}' not found in {target}.")
 
     start_pos += len(start_marker) + len("YYYY-MM-DD")
+    end_marker = f"## [{prev_tag}]" if prev_tag else "<!-- Release links -->"
 
     if prev_tag:
-        end_marker = f"## [{prev_tag}]"
         end_pos = document.find(end_marker, start_pos)
         if end_pos == -1:
             raise ValueError(
-                f"End marker for previous tag '{prev_tag}' not found in the document."
+                f"End marker for previous tag '{prev_tag}' not found in {target}."
             )
     else:
-        end_pos = document.find("<!-- Release links -->", start_pos)
+        end_pos = document.find(end_marker, start_pos)
         if end_pos == -1:
-            raise ValueError(
-                "End marker '<!-- Release links -->' not found in the document."
-            )
+            raise ValueError(f"End marker '{end_marker}' not found in {target}.")
 
     return document[start_pos:end_pos].strip()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
closes: #XXXX

* Force user to write `RELEASE_DESCR` and `CHANGELOG` for all tags from now. We allowed to not write those sections sometimes and worked as best effort (getting latest previous content instead of exact previous tag content if we can't find). I decided to apply this rule to avoid confusion during release process.
* small improvement - allowing version suffix in package path.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/Finschia/finschia/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
