### PR TITLE
chore: Modify the way the binary version is set when compiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (build) [\#340](https://github.com/Finschia/finschia/pull/340) Set Finschia/ostracon version
 * (ci) [\#361](https://github.com/Finschia/finschia/pull/361) Replace deprecated linters with new ones
 * (ci) [\#362](https://github.com/Finschia/finschia/pull/362) Add RELEASE_NOTE.md to .gitignore
-* (swagger) [\#371](https://github.com/Finschia/finschia/pull/371) Add fswap and fbridge swagger settings in swagger config 
+* (swagger) [\#371](https://github.com/Finschia/finschia/pull/371) Add fswap and fbridge swagger settings in swagger config
+* (build) [\#388](https://github.com/Finschia/finschia/pull/388) Modify the way the binary version is set when compiling
 
 ### Docs
 

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,12 @@
 
 COMMIT ?= $(shell git log -1 --format='%H')
 
-# ascribe tag only if on a release/ branch, otherwise pick branch name and concatenate commit hash
+# Specify a tag only if it has a specific tag, otherwise choose a branch name and concatenate the commit hash.
 ifeq (,$(VERSION))
   BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
   VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
-  ifeq (, $(findstring release/,$(BRANCH)))
+  SHORT_COMMIT := $(shell git log -1 --format='%h')
+  ifneq (, $(findstring $(SHORT_COMMIT),$(VERSION)))
     VERSION = $(subst /,_,$(BRANCH))-$(COMMIT)
   endif
 endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Modify the way the binary version is set when compiling.
  * if main branch, `main-f71e2e77b45e64df1ae8790b61f80b192350d688`.
  * if feat/compile_with_tags branch, `feat_compile_with_tags-726c33ee7d7aad03cc4c705c97acbffc67b39bd4`.
  * if v4.0.0 tag commit, `v4.0.0`

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When compiled with the following command, v4.0.0 is not output.
```
git clone https://github.com/Finschia/finschia
cd finschia && git checkout v4.0.0
make install

fnsad version
# HEAD-0d1b05018dc6fa8265f3bc35d9066cbe644c96b3
```

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I followed the [contributing guidelines](https://github.com/Finschia/finschia/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Finschia/finschia/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
